### PR TITLE
Fiji Archipelago

### DIFF
--- a/TrakEM2_/src/main/java/ini/trakem2/persistence/FloatProcessorSASE.java
+++ b/TrakEM2_/src/main/java/ini/trakem2/persistence/FloatProcessorSASE.java
@@ -1,0 +1,37 @@
+package ini.trakem2.persistence;
+
+import ij.process.FloatProcessor;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+
+/**
+ * A metaphorical Self Addressed Stamped Envelope for a FloatProcessor. Allows FloatProcessors to
+ * be Serialized.
+ */
+public class FloatProcessorSASE implements Serializable
+{
+    private transient FloatProcessor processor;
+    private final float[] pixels;
+    private final int width, height;
+
+    public FloatProcessorSASE(FloatProcessor fp)
+    {
+        processor = fp;
+        width = processor.getWidth();
+        height = processor.getHeight();
+        pixels = (float[])processor.getPixels();
+    }
+
+    private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException
+    {
+        ois.defaultReadObject();
+        processor = new FloatProcessor(width, height, pixels);
+    }
+
+    public FloatProcessor getData()
+    {
+        return processor;
+    }
+}

--- a/TrakEM2_/src/main/java/ini/trakem2/utils/AreaUtils.java
+++ b/TrakEM2_/src/main/java/ini/trakem2/utils/AreaUtils.java
@@ -17,6 +17,7 @@ import java.awt.Polygon;
 import java.awt.Rectangle;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
+import java.awt.geom.Path2D;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -522,4 +523,17 @@ public final class AreaUtils {
 		
 		return as;
 	}
+
+        public static Area infiniteArea()
+        {
+            final Path2D.Double path = new Path2D.Double();
+            path.moveTo(Double.MAX_VALUE, Double.MAX_VALUE);
+            path.lineTo(-Double.MAX_VALUE, Double.MAX_VALUE);
+            path.lineTo(-Double.MAX_VALUE, -Double.MAX_VALUE);
+            path.lineTo(Double.MAX_VALUE, -Double.MAX_VALUE);
+            path.lineTo(Double.MAX_VALUE, Double.MAX_VALUE);
+
+            return new Area(path);
+        }
+
 }

--- a/TrakEM2_/src/main/java/mpicbg/trakem2/align/ElasticLayerAlignment.java
+++ b/TrakEM2_/src/main/java/mpicbg/trakem2/align/ElasticLayerAlignment.java
@@ -16,29 +16,29 @@
  */
 package mpicbg.trakem2.align;
 
-
 import ij.IJ;
 import ij.ImagePlus;
 import ij.gui.GenericDialog;
 import ij.process.FloatProcessor;
 import ini.trakem2.Project;
-import ini.trakem2.display.Layer;
-import ini.trakem2.display.LayerSet;
-import ini.trakem2.display.Patch;
+import ini.trakem2.display.*;
+import ini.trakem2.persistence.FloatProcessorSASE;
+import ini.trakem2.utils.AreaUtils;
 import ini.trakem2.utils.Filter;
 import ini.trakem2.utils.Utils;
 
 import java.awt.Color;
 import java.awt.Image;
 import java.awt.Rectangle;
+import java.awt.geom.Area;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import mpicbg.ij.blockmatching.BlockMatching;
 import mpicbg.imagefeatures.Feature;
@@ -60,6 +60,7 @@ import mpicbg.models.TileConfiguration;
 import mpicbg.models.Transforms;
 import mpicbg.models.TranslationModel2D;
 import mpicbg.models.Vertex;
+import mpicbg.trakem2.concurrent.ThreadPool;
 import mpicbg.trakem2.transform.MovingLeastSquaresTransform2;
 import mpicbg.trakem2.util.Triple;
 
@@ -68,6 +69,281 @@ import mpicbg.trakem2.util.Triple;
  */
 public class ElasticLayerAlignment
 {
+
+    private static AtomicLong idGenerator = new AtomicLong(1);
+    private Hashtable<Long, Point> pointCache = new Hashtable<Long, Point>();
+
+    protected synchronized void cachePoints(Collection<? extends Point> points)
+    {
+        for (Point p : points)
+        {
+            if (p.getID() == 0)
+            {
+                p.setID(idGenerator.getAndIncrement());
+                pointCache.put(p.getID(), p);
+            }
+        }
+    }
+
+    protected synchronized void syncPointMatch(Collection<PointMatch> pointMatches)
+    {
+        for (PointMatch pm : pointMatches)
+        {
+            final Point p1 = pm.getP1(), p2 = pm.getP2();
+            if (p1.getID() != 0)
+            {
+                final Point mp1 = pointCache.get(p1.getID());
+                if (mp1 != p1)
+                {
+                    mp1.set(p1);
+                    pm.setP1(mp1);
+                }
+            }
+
+            if (p2.getID() != 0)
+            {
+                final Point mp2 = pointCache.get(p2.getID());
+                if (mp2 != p2)
+                {
+                    mp2.set(p2);
+                    pm.setP2(mp2);
+                }
+            }
+        }
+    }
+
+    protected synchronized void clearPointCache()
+    {
+        pointCache.clear();
+    }
+
+
+    
+    protected static class PMCResults implements Serializable
+    {
+        final public ArrayList<PointMatch> pm12, pm21;
+        final public Triple<Integer, Integer, AbstractModel<?>> pair;
+        final public boolean layer1fixed, layer2fixed;
+        public boolean needsSync;
+
+        public PMCResults(final ArrayList<PointMatch> pm12,
+                          final ArrayList<PointMatch> pm21,
+                          Triple<Integer, Integer, AbstractModel<?>> pair,
+                          final boolean layer1fixed,
+                          final boolean layer2fixed)
+        {
+            this.pm12 = pm12;
+            this.pm21 = pm21;
+            this.pair = pair;
+            this.layer1fixed = layer1fixed;
+            this.layer2fixed = layer2fixed;
+            this.needsSync = false;
+
+        }
+
+        private void readObject(ObjectInputStream input) throws ClassNotFoundException, IOException
+        {
+            input.defaultReadObject();
+            this.needsSync = true;
+        }
+
+    }
+
+    protected static class PointMatchCallable implements Callable<PMCResults>, Serializable
+    {
+        private final Triple<Integer, Integer, AbstractModel<?>> pair;
+        private transient Project project;
+        private transient List<Layer> layerRange;
+        private transient Filter<Patch> filter;
+        private transient Rectangle box;
+
+        private boolean fpsInitted;
+
+        private final boolean layer1Fixed, layer2Fixed;
+
+        private final int blockRadius;
+        private final int searchRadius;
+        private final float minR, maxCurvatureR, rodR, layerScale;
+
+        private final Collection<Vertex> v1, v2;
+
+        private FloatProcessorSASE fp1, fp2, fp1Mask, fp2Mask;
+
+        public PointMatchCallable(final Triple<Integer, Integer, AbstractModel<?>> pair,
+                                  final Project project,
+                                  final List<Layer> layerRange,                                  
+                                  final Filter<Patch> filter,
+                                  final Rectangle box,
+                                  final Collection<Vertex> v1,
+                                  final Collection<Vertex> v2,
+                                  final Param p,
+                                  final boolean layer1Fixed,
+                                  final boolean layer2Fixed)
+        {
+            this.pair = pair;
+            this.project = project;
+            this.layerRange = layerRange;
+            this.filter = filter;
+            this.box = box;
+            this.v1 = v1;
+            this.v2 = v2;
+            this.layer1Fixed = layer1Fixed;
+            this.layer2Fixed = layer2Fixed;
+
+            fp1 = null;
+            fp2 = null;
+            fp1Mask = null;
+            fp2Mask = null;
+
+            fpsInitted = false;
+
+            blockRadius = Math.max( 16, mpicbg.util.Util.roundPos( p.layerScale * p.blockRadius ) );
+
+            /* scale pixel distances */
+            searchRadius = ( int )Math.round( p.layerScale * p.searchRadius );
+
+            rodR = p.rodR;
+            maxCurvatureR = p.maxCurvatureR;
+            minR = p.minR;
+            layerScale = p.layerScale;
+            
+        }
+
+        private void writeObject(ObjectOutputStream outStream) throws IOException
+        {
+            if (!fpsInitted)
+            {
+                generateFPCs();
+            }
+
+            outStream.defaultWriteObject();
+
+            release();
+        }
+
+        private void release()
+        {
+            fp1 = null;
+            fp2 = null;
+            fp1Mask = null;
+            fp2Mask = null;
+            fpsInitted = false;
+            System.gc();
+        }
+
+        private void generateFPCs()                
+        {
+            if (! (layer1Fixed && layer2Fixed))
+            {
+                final Layer layer1 =  layerRange.get( pair.a );
+                final Layer layer2 =  layerRange.get( pair.b );
+                project.getLoader().releaseAll();
+
+                final Image img1 = project.getLoader().getFlatAWTImage(
+                        layer1,
+                        box,
+                        layerScale,
+                        0xffffffff,
+                        ImagePlus.COLOR_RGB,
+                        Patch.class,
+                        AlignmentUtils.filterPatches( layer1, filter ),
+                        true,
+                        new Color( 0x00ffffff, true ) );
+
+                final Image img2 = project.getLoader().getFlatAWTImage(
+                        layer2,
+                        box,
+                        layerScale,
+                        0xffffffff,
+                        ImagePlus.COLOR_RGB,
+                        Patch.class,
+                        AlignmentUtils.filterPatches( layer2, filter ),
+                        true,
+                        new Color( 0x00ffffff, true ) );
+
+                final int width = img1.getWidth( null );
+                final int height = img1.getHeight( null );
+
+                final FloatProcessor ip1 = new FloatProcessor( width, height );
+                final FloatProcessor ip2 = new FloatProcessor( width, height );
+                final FloatProcessor ip1Mask = new FloatProcessor( width, height );
+                final FloatProcessor ip2Mask = new FloatProcessor( width, height );
+
+                mpicbg.trakem2.align.Util.imageToFloatAndMask( img1, ip1, ip1Mask );
+                mpicbg.trakem2.align.Util.imageToFloatAndMask( img2, ip2, ip2Mask );
+
+                fp1 = new FloatProcessorSASE(ip1);
+                fp2 = new FloatProcessorSASE(ip2);
+                fp1Mask = new FloatProcessorSASE(ip1Mask);
+                fp2Mask = new FloatProcessorSASE(ip2Mask);
+            }
+            fpsInitted = true;
+        }
+
+
+        public PMCResults call() throws Exception
+        {
+            if (!fpsInitted)
+            {
+                generateFPCs();
+            }
+
+            ArrayList< PointMatch > pm12 = new ArrayList< PointMatch >();
+            ArrayList< PointMatch > pm21 = new ArrayList< PointMatch >();
+
+            if (!layer1Fixed)
+            {
+                BlockMatching.matchByMaximalPMCC(
+                        fp1.getData(),
+                        fp2.getData(),
+                        fp1Mask.getData(),
+                        fp2Mask.getData(),
+                        1.0f,
+                        ( ( InvertibleCoordinateTransform )pair.c ).createInverse(),
+                        blockRadius,
+                        blockRadius,
+                        searchRadius,
+                        searchRadius,
+                        minR,
+                        rodR,
+                        maxCurvatureR,
+                        v1,
+                        pm12,
+                        new ErrorStatistic( 1 ) );
+            }
+
+            if (!layer2Fixed)
+            {
+                BlockMatching.matchByMaximalPMCC(
+                        fp2.getData(),
+                        fp1.getData(),
+                        fp2Mask.getData(),
+                        fp1Mask.getData(),
+                        1.0f,
+                        pair.c,
+                        blockRadius,
+                        blockRadius,
+                        searchRadius,
+                        searchRadius,
+                        minR,
+                        rodR,
+                        maxCurvatureR,
+                        v2,
+                        pm21,
+                        new ErrorStatistic( 1 ) );
+            }
+            
+            release();
+
+            System.out.println("Done");
+
+            return new PMCResults(pm12, pm21, pair, layer1Fixed, layer2Fixed);
+        }
+    }
+
+
+
+
 	final static public class Param extends AbstractLayerAlignmentParam implements Serializable
 	{
 		private static final long serialVersionUID = 398966126705836033L;
@@ -377,8 +653,6 @@ public class ElasticLayerAlignment
 	 * @param fixedLayers
 	 * @param emptyLayers
 	 * @param box
-	 * @param propagateTransform
-	 * @param fov
 	 * @param filter
 	 * @throws Exception
 	 */
@@ -395,6 +669,7 @@ public class ElasticLayerAlignment
 	{
 		final double scale = Math.min( 1.0, Math.min( ( double )param.ppm.sift.maxOctaveSize / ( double )box.width, ( double )param.ppm.sift.maxOctaveSize / ( double )box.height ) );
 		
+        System.out.println("Your are using TrakEM Larry Rev B");
 		
 		/* create tiles and models for all layers */
 		final ArrayList< Tile< ? > > tiles = new ArrayList< Tile< ? > >();
@@ -672,13 +947,21 @@ J:				for ( int j = i + 1; j < range; )
 		Utils.log( "effective block radius = " + blockRadius );
 		
 		/* scale pixel distances */
-		final int searchRadius = ( int )Math.round( param.layerScale * param.searchRadius );
+		//final int searchRadius = ( int )Math.round( param.layerScale * param.searchRadius );
 		final float localRegionSigma = param.layerScale * param.localRegionSigma;
 		final float maxLocalEpsilon = param.layerScale * param.maxLocalEpsilon;
 		
 		final AbstractModel< ? > localSmoothnessFilterModel = Util.createModel( param.localModelIndex );
 		
-		
+        final ExecutorService executor = ThreadPool.getExecutorService(1.0f);
+        
+		final ArrayList<Future<PMCResults>> results = new ArrayList<Future<PMCResults>>(pairs.size());
+
+        for (SpringMesh mesh : meshes)
+        {
+            cachePoints(mesh.getVertices());
+        }
+        
 		for ( final Triple< Integer, Integer, AbstractModel< ? > > pair : pairs )
 		{
 			/* free memory */
@@ -686,9 +969,6 @@ J:				for ( int j = i + 1; j < range; )
 			
 			final SpringMesh m1 = meshes.get( pair.a );
 			final SpringMesh m2 = meshes.get( pair.b );
-
-			final ArrayList< PointMatch > pm12 = new ArrayList< PointMatch >();
-			final ArrayList< PointMatch > pm21 = new ArrayList< PointMatch >();
 
 			final Collection< Vertex > v1 = m1.getVertices();
 			final Collection< Vertex > v2 = m2.getVertices();
@@ -699,208 +979,175 @@ J:				for ( int j = i + 1; j < range; )
 			final boolean layer1Fixed = fixedLayers.contains( layer1 );
 			final boolean layer2Fixed = fixedLayers.contains( layer2 );
 			
-			final Tile< ? > t1 = tiles.get( pair.a );
-			final Tile< ? > t2 = tiles.get( pair.b );
-			
-			if ( !( layer1Fixed && layer2Fixed ) )
-			{
-				final Image img1 = project.getLoader().getFlatAWTImage(
-						layer1,
-						box,
-						param.layerScale,
-						0xffffffff,
-						ImagePlus.COLOR_RGB,
-						Patch.class,
-						AlignmentUtils.filterPatches( layer1, filter ),
-						true,
-						new Color( 0x00ffffff, true ) );
-				
-				final Image img2 = project.getLoader().getFlatAWTImage(
-						layer2,
-						box,
-						param.layerScale,
-						0xffffffff,
-						ImagePlus.COLOR_RGB,
-						Patch.class,
-						AlignmentUtils.filterPatches( layer2, filter ),
-						true,
-						new Color( 0x00ffffff, true ) );
-				
-				final int width = img1.getWidth( null );
-				final int height = img1.getHeight( null );
-	
-				final FloatProcessor ip1 = new FloatProcessor( width, height );
-				final FloatProcessor ip2 = new FloatProcessor( width, height );
-				final FloatProcessor ip1Mask = new FloatProcessor( width, height );
-				final FloatProcessor ip2Mask = new FloatProcessor( width, height );
-				
-				mpicbg.trakem2.align.Util.imageToFloatAndMask( img1, ip1, ip1Mask );
-				mpicbg.trakem2.align.Util.imageToFloatAndMask( img2, ip2, ip2Mask );
-				
-				final float springConstant  = 1.0f / ( pair.b - pair.a );
-				
-				if ( layer1Fixed )
-					initMeshes.fixTile( t1 );
-				else
-				{
-					try
-					{
-						BlockMatching.matchByMaximalPMCC(
-								ip1,
-								ip2,
-								ip1Mask,
-								ip2Mask,
-								1.0f,
-								( ( InvertibleCoordinateTransform )pair.c ).createInverse(),
-								blockRadius,
-								blockRadius,
-								searchRadius,
-								searchRadius,
-								param.minR,
-								param.rodR,
-								param.maxCurvatureR,
-								v1,
-								pm12,
-								new ErrorStatistic( 1 ) );
-					}
-					catch ( final InterruptedException e )
-					{
-						Utils.log( "Block matching interrupted." );
-						IJ.showProgress( 1.0 );
-						return;
-					}
-					if ( Thread.interrupted() )
-					{
-						Utils.log( "Block matching interrupted." );
-						IJ.showProgress( 1.0 );
-						return;
-					}
-		
-					if ( param.useLocalSmoothnessFilter )
-					{
-						Utils.log( pair.a + " > " + pair.b + ": found " + pm12.size() + " correspondence candidates." );
-						localSmoothnessFilterModel.localSmoothnessFilter( pm12, pm12, localRegionSigma, maxLocalEpsilon, param.maxLocalTrust );
-						Utils.log( pair.a + " > " + pair.b + ": " + pm12.size() + " candidates passed local smoothness filter." );
-					}
-					else
-					{
-						Utils.log( pair.a + " > " + pair.b + ": found " + pm12.size() + " correspondences." );
-					}
-		
-					/* <visualisation> */
-					//			final List< Point > s1 = new ArrayList< Point >();
-					//			PointMatch.sourcePoints( pm12, s1 );
-					//			final ImagePlus imp1 = new ImagePlus( i + " >", ip1 );
-					//			imp1.show();
-					//			imp1.setOverlay( BlockMatching.illustrateMatches( pm12 ), Color.yellow, null );
-					//			imp1.setRoi( Util.pointsToPointRoi( s1 ) );
-					//			imp1.updateAndDraw();
-					/* </visualisation> */
-					
-					for ( final PointMatch pm : pm12 )
-					{
-						final Vertex p1 = ( Vertex )pm.getP1();
-						final Vertex p2 = new Vertex( pm.getP2() );
-						p1.addSpring( p2, new Spring( 0, springConstant ) );
-						m2.addPassiveVertex( p2 );
-					}
-					
-					/*
-					 * adding Tiles to the initialing TileConfiguration, adding a Tile
-					 * multiple times does not harm because the TileConfiguration is
-					 * backed by a Set. 
-					 */
-					if ( pm12.size() > pair.c.getMinNumMatches() )
-					{
-						initMeshes.addTile( t1 );
-						initMeshes.addTile( t2 );
-						t1.connect( t2, pm12 );
-					}
-				}
-	
-				if ( layer2Fixed )
-					initMeshes.fixTile( t2 );
-				else
-				{
-					try
-					{
-						BlockMatching.matchByMaximalPMCC(
-								ip2,
-								ip1,
-								ip2Mask,
-								ip1Mask,
-								1.0f,
-								pair.c,
-								blockRadius,
-								blockRadius,
-								searchRadius,
-								searchRadius,
-								param.minR,
-								param.rodR,
-								param.maxCurvatureR,
-								v2,
-								pm21,
-								new ErrorStatistic( 1 ) );
-					}
-					catch ( final InterruptedException e )
-					{
-						Utils.log( "Block matching interrupted." );
-						IJ.showProgress( 1.0 );
-						return;
-					}
-					if ( Thread.interrupted() )
-					{
-						Utils.log( "Block matching interrupted." );
-						IJ.showProgress( 1.0 );
-						return;
-					}
-		
-					if ( param.useLocalSmoothnessFilter )
-					{
-						Utils.log( pair.a + " < " + pair.b + ": found " + pm21.size() + " correspondence candidates." );
-						localSmoothnessFilterModel.localSmoothnessFilter( pm21, pm21, localRegionSigma, maxLocalEpsilon, param.maxLocalTrust );
-						Utils.log( pair.a + " < " + pair.b + ": " + pm21.size() + " candidates passed local smoothness filter." );
-					}
-					else
-					{
-						Utils.log( pair.a + " < " + pair.b + ": found " + pm21.size() + " correspondences." );
-					}
-					
-					/* <visualisation> */
-					//			final List< Point > s2 = new ArrayList< Point >();
-					//			PointMatch.sourcePoints( pm21, s2 );
-					//			final ImagePlus imp2 = new ImagePlus( i + " <", ip2 );
-					//			imp2.show();
-					//			imp2.setOverlay( BlockMatching.illustrateMatches( pm21 ), Color.yellow, null );
-					//			imp2.setRoi( Util.pointsToPointRoi( s2 ) );
-					//			imp2.updateAndDraw();
-					/* </visualisation> */
-					
-					for ( final PointMatch pm : pm21 )
-					{
-						final Vertex p1 = ( Vertex )pm.getP1();
-						final Vertex p2 = new Vertex( pm.getP2() );
-						p1.addSpring( p2, new Spring( 0, springConstant ) );
-						m1.addPassiveVertex( p2 );
-					}
-					
-					/*
-					 * adding Tiles to the initialing TileConfiguration, adding a Tile
-					 * multiple times does not harm because the TileConfiguration is
-					 * backed by a Set. 
-					 */
-					if ( pm21.size() > pair.c.getMinNumMatches() )
-					{
-						initMeshes.addTile( t1 );
-						initMeshes.addTile( t2 );
-						t2.connect( t1, pm21 );
-					}
-				}
-				
-				Utils.log( pair.a + " <> " + pair.b + " spring constant = " + springConstant );
-			}
-		}
-		
+                results.add(executor.submit(new PointMatchCallable(
+                        pair,
+                        project,
+                        layerRange,
+                        filter,
+                        box,
+                        v1,
+                        v2,
+                        param,
+                        layer1Fixed,
+                        layer2Fixed)));
+        }
+
+        for (Future<PMCResults> future : results)
+        {
+
+            PMCResults pmcResult;
+            try
+            {
+                pmcResult = future.get();
+            }
+            catch (ExecutionException ee)
+            {
+                Utils.log( "Block matching interrupted." );
+                IJ.showProgress( 1.0 );
+                return;
+            }
+            catch (InterruptedException ie)
+            {
+                Utils.log( "Block matching interrupted." );
+                IJ.showProgress( 1.0 );
+                return;
+            }
+
+            final Triple<Integer, Integer, AbstractModel<?>> pair = pmcResult.pair;
+            final float springConstant  = 1.0f / ( pair.b - pair.a );
+            boolean layer1Fixed = pmcResult.layer1fixed;
+            boolean layer2Fixed = pmcResult.layer2fixed;
+            final Tile<?> t1 = tiles.get(pair.a);
+            final Tile<?> t2 = tiles.get(pair.b);
+            final SpringMesh m1 = meshes.get( pair.a );
+            final SpringMesh m2 = meshes.get( pair.b );
+
+            final ArrayList< PointMatch > pm12 = pmcResult.pm12;
+            final ArrayList< PointMatch > pm21 = pmcResult.pm21;
+
+            if ( !( layer1Fixed && layer2Fixed ))
+            {
+
+                if (pmcResult.needsSync)
+                {
+                    syncPointMatch(pmcResult.pm12);
+                    syncPointMatch(pmcResult.pm21);
+                }
+
+                if ( layer1Fixed )
+                {
+                    initMeshes.fixTile( t1 );
+                }
+                else
+                {
+
+                    if ( param.useLocalSmoothnessFilter )
+                    {
+                        Utils.log( pair.a + " > " + pair.b + ": found " + pm12.size() + " correspondence candidates." );
+                        localSmoothnessFilterModel.localSmoothnessFilter( pm12, pm12, localRegionSigma, maxLocalEpsilon, param.maxLocalTrust );
+                        Utils.log( pair.a + " > " + pair.b + ": " + pm12.size() + " candidates passed local smoothness filter." );
+                    }
+                    else
+                    {
+                        Utils.log( pair.a + " > " + pair.b + ": found " + pm12.size() + " correspondences." );
+                    }
+
+                    /* <visualisation> */
+                    //			final List< Point > s1 = new ArrayList< Point >();
+                    //			PointMatch.sourcePoints( pm12, s1 );
+                    //			final ImagePlus imp1 = new ImagePlus( i + " >", ip1 );
+                    //			imp1.show();
+                    //			imp1.setOverlay( BlockMatching.illustrateMatches( pm12 ), Color.yellow, null );
+                    //			imp1.setRoi( Util.pointsToPointRoi( s1 ) );
+                    //			imp1.updateAndDraw();
+                    /* </visualisation> */
+
+                    for ( final PointMatch pm : pm12 )
+                    {
+                        final Vertex p1 = ( Vertex )pm.getP1();
+                        final Vertex p2 = new Vertex( pm.getP2() );
+                        p1.addSpring( p2, new Spring( 0, springConstant ) );
+                        m2.addPassiveVertex( p2 );
+                    }
+
+                    /*
+                    * adding Tiles to the initialing TileConfiguration, adding a Tile
+                    * multiple times does not harm because the TileConfiguration is
+                    * backed by a Set.
+                    */
+                    if ( pm12.size() > pair.c.getMinNumMatches() )
+                    {
+                        initMeshes.addTile( t1 );
+                        initMeshes.addTile( t2 );
+                        t1.connect( t2, pm12 );
+                    }
+                }
+
+                if ( layer2Fixed )
+                    initMeshes.fixTile( t2 );
+                else
+                {
+//                catch ( final InterruptedException e )
+//                {
+//                    Utils.log( "Block matching interrupted." );
+//                    IJ.showProgress( 1.0 );
+//                    return;
+//                }
+//                if ( Thread.interrupted() )
+//                {
+//                    Utils.log( "Block matching interrupted." );
+//                    IJ.showProgress( 1.0 );
+//                    return;
+//                }
+
+                    if ( param.useLocalSmoothnessFilter )
+                    {
+                        Utils.log( pair.a + " < " + pair.b + ": found " + pm21.size() + " correspondence candidates." );
+                        localSmoothnessFilterModel.localSmoothnessFilter( pm21, pm21, localRegionSigma, maxLocalEpsilon, param.maxLocalTrust );
+                        Utils.log( pair.a + " < " + pair.b + ": " + pm21.size() + " candidates passed local smoothness filter." );
+                    }
+                    else
+                    {
+                        Utils.log( pair.a + " < " + pair.b + ": found " + pm21.size() + " correspondences." );
+                    }
+
+                    /* <visualisation> */
+                    //			final List< Point > s2 = new ArrayList< Point >();
+                    //			PointMatch.sourcePoints( pm21, s2 );
+                    //			final ImagePlus imp2 = new ImagePlus( i + " <", ip2 );
+                    //			imp2.show();
+                    //			imp2.setOverlay( BlockMatching.illustrateMatches( pm21 ), Color.yellow, null );
+                    //			imp2.setRoi( Util.pointsToPointRoi( s2 ) );
+                    //			imp2.updateAndDraw();
+                    /* </visualisation> */
+
+                    for ( final PointMatch pm : pm21 )
+                    {
+                        final Vertex p1 = ( Vertex )pm.getP1();
+                        final Vertex p2 = new Vertex( pm.getP2() );
+                        p1.addSpring( p2, new Spring( 0, springConstant ) );
+                        m1.addPassiveVertex( p2 );
+                    }
+
+                    /*
+                    * adding Tiles to the initialing TileConfiguration, adding a Tile
+                    * multiple times does not harm because the TileConfiguration is
+                    * backed by a Set.
+                    */
+                    if ( pm21.size() > pair.c.getMinNumMatches() )
+                    {
+                        initMeshes.addTile( t1 );
+                        initMeshes.addTile( t2 );
+                        t2.connect( t1, pm21 );
+                    }
+                }
+
+                Utils.log( pair.a + " <> " + pair.b + " spring constant = " + springConstant );
+            }
+        }
+
+        clearPointCache();
+
 		/* pre-align by optimizing a piecewise linear model */ 
 		initMeshes.optimize(
 				param.maxEpsilon * param.layerScale,
@@ -954,6 +1201,16 @@ J:				for ( int j = i + 1; j < range; )
 		final Layer first = layerRange.get( 0 );
 		final List< Layer > layers = first.getParent().getLayers();
 		
+        final List<VectorData> vectorData = new ArrayList<VectorData>();
+        vectorData.addAll(first.getParent().getAll(AreaList.class));
+        vectorData.addAll(first.getParent().getAll(Ball.class));
+        vectorData.addAll(first.getParent().getAll(Dissector.class));
+        vectorData.addAll(first.getParent().getAll(Pipe.class));
+        vectorData.addAll(first.getParent().getAll(Polyline.class));
+        vectorData.addAll(first.getParent().getAll(Tree.class));
+        
+        Area infArea = AreaUtils.infiniteArea();
+        
 		/* transfer layer transform into patch transforms and append to patches */
 		if ( propagateTransformBefore || propagateTransformAfter )
 		{
@@ -984,8 +1241,24 @@ J:				for ( int j = i + 1; j < range; )
 			mlt.setModel( AffineModel2D.class );
 			mlt.setAlpha( 2.0f );
 			mlt.setMatches( meshes.get( l ).getVA().keySet() );
-			
-			applyTransformToLayer( layer, mlt, filter );
+
+            for (VectorData vectorDatum : vectorData)
+            {
+                vectorDatum.apply(layer, infArea, mlt);
+            }
+
+            for (DLabel dl : layer.getAll(DLabel.class))
+            {
+                dl.apply(layer, infArea, mlt);
+            }
+
+            for (Profile p : layer.getAll(Profile.class))
+            {
+                p.apply(layer, infArea, mlt);
+            }
+
+
+            applyTransformToLayer( layer, mlt, filter );
 					
 			if ( Thread.interrupted() )
 			{
@@ -1053,7 +1326,7 @@ J:				for ( int j = i + 1; j < range; )
 			final Thread thread = new Thread(
 					new Runnable()
 					{
-						@Override
+						//@Override
 						final public void run()
 						{
 							try

--- a/TrakEM2_/src/main/java/mpicbg/trakem2/concurrent/DefaultExecutorProvider.java
+++ b/TrakEM2_/src/main/java/mpicbg/trakem2/concurrent/DefaultExecutorProvider.java
@@ -1,0 +1,24 @@
+package mpicbg.trakem2.concurrent;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Default Executor Provider, which creates ExecutorServices from java.util.concurrent.Executors
+ *
+ * @author Larry Lindsey
+ */
+public class DefaultExecutorProvider implements ExecutorProvider
+{
+    public ExecutorService getService(int nThreads)
+    {
+        return Executors.newFixedThreadPool(nThreads);
+    }
+    
+    public ExecutorService getService(float fractionThreads)
+    {
+        int nc = (int)(fractionThreads *
+                (float)Runtime.getRuntime().availableProcessors());
+        return Executors.newFixedThreadPool(nc > 0 ? nc : 1);
+    }
+}

--- a/TrakEM2_/src/main/java/mpicbg/trakem2/concurrent/ExecutorProvider.java
+++ b/TrakEM2_/src/main/java/mpicbg/trakem2/concurrent/ExecutorProvider.java
@@ -1,0 +1,17 @@
+package mpicbg.trakem2.concurrent;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Interface to allow configurability of distributed jobs in TrakEM2
+ *
+ * @author Larry Lindsey
+ */
+public interface ExecutorProvider
+{
+
+    public ExecutorService getService(int nThreads);
+    
+    public ExecutorService getService(float fractionThreads);
+
+}

--- a/TrakEM2_/src/main/java/mpicbg/trakem2/concurrent/ThreadPool.java
+++ b/TrakEM2_/src/main/java/mpicbg/trakem2/concurrent/ThreadPool.java
@@ -1,0 +1,35 @@
+package mpicbg.trakem2.concurrent;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Access to a centralized thread pool.
+ * 
+ * @author Larry Lindsey
+ */
+public class ThreadPool
+{
+    
+    private static ExecutorProvider provider = new DefaultExecutorProvider();
+    
+    public static ExecutorService getExecutorService(final int nThreads)
+    {
+        return provider.getService(nThreads);
+    }
+    
+    public static ExecutorService getExecutorService(final float fractionThreads)
+    {
+        return provider.getService(fractionThreads);
+    }
+    
+    public static void setProvider(final ExecutorProvider ep)
+    {
+        provider = ep;
+    }
+
+    public static ExecutorProvider getProvider()
+    {
+        return provider;
+    }
+    
+}

--- a/TrakEM2_/src/main/java/mpicbg/trakem2/util/Triple.java
+++ b/TrakEM2_/src/main/java/mpicbg/trakem2/util/Triple.java
@@ -1,6 +1,8 @@
 package mpicbg.trakem2.util;
 
-public class Triple<A, B, C>
+import java.io.Serializable;
+
+public class Triple<A, B, C> implements Serializable
 {
 	public final A a;
 	public final B b;


### PR DESCRIPTION
Allows ElasticLayerAlignment to use a Fiji archipelago.Cluster.

Primary changes:
Use an ExecutorService to submit BlockMatchPMCC point matching
- https://github.com/larrylindsey/TrakEM2/blob/master/TrakEM2_/src/main/java/mpicbg/trakem2/align/ElasticLayerAlignment.java#L982
  Addition of the ThreadPool and ExecutorProvider classes, to allow an ExecutorService to be supplied externally. This was done to allow the use of archipelago.Cluster without an explicit dependency on it.
- https://github.com/larrylindsey/TrakEM2/tree/master/TrakEM2_/src/main/java/mpicbg/trakem2/concurrent
