### PR TITLE
Fix TrakEM2_ dependency versions in plugins

### DIFF
--- a/T2-NIT/pom.xml
+++ b/T2-NIT/pom.xml
@@ -26,7 +26,7 @@
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>TrakEM2_</artifactId>
-			<version>${imagej.version}</version>
+			<version>${trakem2.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>

--- a/T2-TreelineGraph/pom.xml
+++ b/T2-TreelineGraph/pom.xml
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>TrakEM2_</artifactId>
-			<version>${imagej.version}</version>
+			<version>${trakem2.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,10 @@
 	<name>Aggregator project for Albert Cardona's TrakEM2 software suite</name>
 	<description></description>
 
+	<properties>
+		<trakem2.version>1.0b-SNAPSHOT</trakem2.version>
+	</properties>
+
 	<modules>
 		<module>TrakEM2_</module>
 		<module>VectorString</module>


### PR DESCRIPTION
I overlooked this in December, sorry. We do want T2-\* to depend on the correct
TrakEM2_ version, right?

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
