### PR TITLE
Enable maven-enforcer-plugin again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>sc.fiji</groupId>
 		<artifactId>pom-fiji</artifactId>
-		<version>6.1.1</version>
+		<version>6.1.3</version>
 		<relativePath />
 	</parent>
 
@@ -83,8 +83,6 @@
 			<plugin>
 				<artifactId>maven-enforcer-plugin</artifactId>
 				<configuration>
-					<!-- HACK: Until requireReproducibleBuilds can be selectively disabled. -->
-					<skip>true</skip>
 					<rules>
 						<requireReleaseDeps>
 							<!-- HACK: See https://jira.codehaus.org/browse/MENFORCER-185 -->


### PR DESCRIPTION
Updated to pom-fiji 6.1.3, which allows the maven-enforcer-plugin to be used again.
