### PR TITLE
Fix package names of Java3D objects

### DIFF
--- a/TrakEM2_/src/main/java/ini/trakem2/display/Ball.java
+++ b/TrakEM2_/src/main/java/ini/trakem2/display/Ball.java
@@ -930,7 +930,7 @@ public class Ball extends ZDisplayable implements VectorData {
 	/** Put all balls as a single 'mesh'; the returned list contains all faces as three consecutive Point3f. The mesh is also translated by x,y,z of this Displayable.*/
 	public List<Point3f> generateTriangles(final double scale, final double[][][] globe) {
 		try {
-			Class.forName("javax.vecmath.Point3f");
+			Class.forName("org.scijava.vecmath.Point3f");
 		} catch (final ClassNotFoundException cnfe) {
 			Utils.log("Java3D is not installed.");
 			return null;

--- a/TrakEM2_/src/main/java/ini/trakem2/display/Display3D.java
+++ b/TrakEM2_/src/main/java/ini/trakem2/display/Display3D.java
@@ -289,7 +289,7 @@ public final class Display3D {
 		if (check_j3d) {
 			check_j3d = false;
 			try {
-				Class.forName("javax.vecmath.Point3f");
+				Class.forName("org.scijava.vecmath.Point3f");
 				has_j3d_3dviewer = true;
 			} catch (final ClassNotFoundException cnfe) {
 				Utils.log("Java 3D not installed.");

--- a/TrakEM2_/src/main/java/ini/trakem2/utils/Utils.java
+++ b/TrakEM2_/src/main/java/ini/trakem2/utils/Utils.java
@@ -980,7 +980,7 @@ public class Utils implements ij.plugin.PlugIn {
 
 	static private final boolean isJava3DInstalled() {
 		try {
-			Class.forName("javax.vecmath.Point3f");
+			Class.forName("org.scijava.vecmath.Point3f");
 		} catch (final ClassNotFoundException cnfe) {
 			return false;
 		}


### PR DESCRIPTION
Without this fix, TrakEM2 would falsely complain about "Java3D not being installed" while it was just looking for the wrong class.