### PR TITLE
Fix toolbar layout and LAF overriding on Linux

### DIFF
--- a/src/main/java/ini/trakem2/ControlWindow.java
+++ b/src/main/java/ini/trakem2/ControlWindow.java
@@ -123,7 +123,7 @@ public class ControlWindow {
 
 	static public void setLookAndFeel() {
 		try {
-			if (ij.IJ.isLinux()) {
+			if (ij.IJ.isLinux() && "com.sun.java.swing.plaf.nimbus.NimbusLookAndFeel".equals(UIManager.getLookAndFeel().getClass().getName())) {
 				// Nimbus looks great but it's unstable: after a while, swing components stop repainting, throwing all sort of exceptions.
 				//UIManager.setLookAndFeel("com.sun.java.swing.plaf.nimbus.NimbusLookAndFeel");
 				UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");

--- a/src/main/java/ini/trakem2/Project.java
+++ b/src/main/java/ini/trakem2/Project.java
@@ -100,7 +100,7 @@ public class Project extends DBObject {
 	static {
 		try {
 			//UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-			if (IJ.isLinux()) {
+			if (ij.IJ.isLinux() && "com.sun.java.swing.plaf.nimbus.NimbusLookAndFeel".equals(UIManager.getLookAndFeel().getClass().getName())) {
 				UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
 				if (null != IJ.getInstance()) javax.swing.SwingUtilities.updateComponentTreeUI(IJ.getInstance());
 				//if ("albert".equals(System.getProperty("user.name"))) UIManager.setLookAndFeel("com.sun.java.swing.plaf.nimbus.NimbusLookAndFeel");
@@ -770,7 +770,7 @@ public class Project extends DBObject {
 		}
 		if (loader.hasChanges() && !getBooleanProperty("no_shutdown_hook")) { // DBLoader always returns false
 			if (ControlWindow.isGUIEnabled()) {
-				final YesNoDialog yn = ControlWindow.makeYesNoDialog("TrakEM2", "There are unsaved changes in project " + title + ". Save them?");
+				final YesNoDialog yn = ControlWindow.makeYesNoDialog("TrakEM2", "There are unsaved changes in project " + title + ".\nSave them?");
 				if (yn.yesPressed()) {
 					save();
 				}

--- a/src/main/java/ini/trakem2/display/Display.java
+++ b/src/main/java/ini/trakem2/display/Display.java
@@ -41,6 +41,7 @@ import java.awt.Insets;
 import java.awt.Point;
 import java.awt.Polygon;
 import java.awt.Rectangle;
+import java.awt.RenderingHints;
 import java.awt.Scrollbar;
 import java.awt.TextField;
 import java.awt.Toolkit;
@@ -1173,6 +1174,7 @@ public final class Display extends DBObject implements ActionListener, IJEventLi
 		Field OFFSET;
 		Toolbar toolbar = Toolbar.getInstance();
 		int size;
+		int scale = 1;
 		//int offset;
 		ToolbarPanel() {
 			setBackground(Color.white);
@@ -1182,17 +1184,21 @@ public final class Display extends DBObject implements ActionListener, IJEventLi
 				drawButton.setAccessible(true);
 				lineType = Toolbar.class.getDeclaredField("lineType");
 				lineType.setAccessible(true);
-				SIZE = Toolbar.class.getDeclaredField("SIZE");
+				SIZE = Toolbar.class.getDeclaredField("buttonHeight");
 				SIZE.setAccessible(true);
 				OFFSET = Toolbar.class.getDeclaredField("OFFSET");
 				OFFSET.setAccessible(true);
 				size = ((Integer)SIZE.get(null)).intValue();
 				//offset = ((Integer)OFFSET.get(null)).intValue();
+				Field scaleField = Toolbar.class.getDeclaredField("scale");
+				scaleField.setAccessible(true);
+				scale = ((Integer)scaleField.get(null)).intValue();
 			} catch (final Exception e) {
 				IJError.print(e);
+				scale = 1;
 			}
 			// Magic cocktail:
-			final Dimension dim = new Dimension(250, size+size);
+			final Dimension dim = new Dimension(9 * size, size+size); // 9 buttons per row
 			setMinimumSize(dim);
 			setPreferredSize(dim);
 			setMaximumSize(dim);
@@ -1207,6 +1213,17 @@ public final class Display extends DBObject implements ActionListener, IJEventLi
 				// in incorrectly positioned toolbar buttons.
 				final BufferedImage bi = new BufferedImage(getWidth(), getHeight(), BufferedImage.TYPE_INT_RGB);
 				final Graphics g = bi.getGraphics();
+				// Use same hints as ij.gui.Toolbar 
+				Graphics2D g2d = (Graphics2D)g;
+				g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+				g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+				// Set stroke as per ij.gui.Toolbar
+				if (scale==1) {
+					if (ij.Prefs.getGuiScale()>1.0)
+						g2d.setStroke(new BasicStroke(IJ.isMacOSX()?1.4f:1.25f));
+				} else {
+					g2d.setStroke(new BasicStroke(scale));
+				}
 				g.setColor(Color.white);
 				g.fillRect(0, 0, getWidth(), getHeight());
 				int i = 0;

--- a/src/main/java/ini/trakem2/display/YesNoDialog.java
+++ b/src/main/java/ini/trakem2/display/YesNoDialog.java
@@ -91,6 +91,7 @@ public class YesNoDialog extends Dialog implements ActionListener, KeyListener {
 		}
 		add("South", panel);
 		pack();
+		GUI.scale(this);
 		GUI.center(this);
 		if (show) setVisible(true);
 	}


### PR DESCRIPTION
- Fixes layout of toolbar in IJ1.53
- Renders toolbar using same anti-aliasing etc. of IJ1.53
- In Linux, the metal LAF is only applied if the problematic Nimbus L&F is in use
- Scales toolbar and YesNoDialog (AWT) to reflect IJ's scaling factor (Edit>Options>Appearance)

See discussion in  #30 