### PR TITLE
fix: fix broken XML export in In Java 9+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,7 @@
 
 	<properties>
 		<package-name>ini.trakem2</package-name>
+		<trakem2.add-opens></trakem2.add-opens>
 
 		<license.licenseName>gpl_v3</license.licenseName>
 		<license.copyrightOwners>Albert Cardona, Stephan Saalfeld and others.</license.copyrightOwners>
@@ -276,4 +277,28 @@
 			<optional>true</optional>
 		</dependency>
 	</dependencies>
+
+		<build>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<configuration>
+						<argLine>${argLine} ${trakem2.add-opens}</argLine>
+					</configuration>
+				</plugin>
+			</plugins>
+		</build>
+
+		<profiles>
+			<profile>
+				<id>trakem2-add-opens</id>
+				<activation>
+					<jdk>[9,)</jdk>
+				</activation>
+				<properties>
+					<trakem2.add-opens>--add-opens java.base/java.lang=ALL-UNNAMED</trakem2.add-opens>
+				</properties>
+			</profile>
+		</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>38.0.1</version>
+		<version>43.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -277,28 +277,4 @@
 			<optional>true</optional>
 		</dependency>
 	</dependencies>
-
-		<build>
-			<plugins>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-surefire-plugin</artifactId>
-					<configuration>
-						<argLine>${argLine} ${trakem2.add-opens}</argLine>
-					</configuration>
-				</plugin>
-			</plugins>
-		</build>
-
-		<profiles>
-			<profile>
-				<id>trakem2-add-opens</id>
-				<activation>
-					<jdk>[9,)</jdk>
-				</activation>
-				<properties>
-					<trakem2.add-opens>--add-opens java.base/java.lang=ALL-UNNAMED</trakem2.add-opens>
-				</properties>
-			</profile>
-		</profiles>
 </project>

--- a/src/main/java/bunwarpj/trakem2/transform/CubicBSplineTransform.java
+++ b/src/main/java/bunwarpj/trakem2/transform/CubicBSplineTransform.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/ControlWindow.java
+++ b/src/main/java/ini/trakem2/ControlWindow.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/New_DB_Project.java
+++ b/src/main/java/ini/trakem2/New_DB_Project.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/New_Project.java
+++ b/src/main/java/ini/trakem2/New_Project.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/Open_DB_Project.java
+++ b/src/main/java/ini/trakem2/Open_DB_Project.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/Open_Project.java
+++ b/src/main/java/ini/trakem2/Open_Project.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/Project.java
+++ b/src/main/java/ini/trakem2/Project.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/analysis/Centrality.java
+++ b/src/main/java/ini/trakem2/analysis/Centrality.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/analysis/Compare.java
+++ b/src/main/java/ini/trakem2/analysis/Compare.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/analysis/Graph.java
+++ b/src/main/java/ini/trakem2/analysis/Graph.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/analysis/Vertex.java
+++ b/src/main/java/ini/trakem2/analysis/Vertex.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/AbstractOffscreenThread.java
+++ b/src/main/java/ini/trakem2/display/AbstractOffscreenThread.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/AbstractRepaintThread.java
+++ b/src/main/java/ini/trakem2/display/AbstractRepaintThread.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/AffineTransformMode.java
+++ b/src/main/java/ini/trakem2/display/AffineTransformMode.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/AreaContainer.java
+++ b/src/main/java/ini/trakem2/display/AreaContainer.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/AreaList.java
+++ b/src/main/java/ini/trakem2/display/AreaList.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/AreaTree.java
+++ b/src/main/java/ini/trakem2/display/AreaTree.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/AreaWrapper.java
+++ b/src/main/java/ini/trakem2/display/AreaWrapper.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Ball.java
+++ b/src/main/java/ini/trakem2/display/Ball.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Bucket.java
+++ b/src/main/java/ini/trakem2/display/Bucket.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Bucketable.java
+++ b/src/main/java/ini/trakem2/display/Bucketable.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Channel.java
+++ b/src/main/java/ini/trakem2/display/Channel.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Connector.java
+++ b/src/main/java/ini/trakem2/display/Connector.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/ContrastAdjustmentMode.java
+++ b/src/main/java/ini/trakem2/display/ContrastAdjustmentMode.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Coordinate.java
+++ b/src/main/java/ini/trakem2/display/Coordinate.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/DLabel.java
+++ b/src/main/java/ini/trakem2/display/DLabel.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/DefaultMode.java
+++ b/src/main/java/ini/trakem2/display/DefaultMode.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Display.java
+++ b/src/main/java/ini/trakem2/display/Display.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Display3D.java
+++ b/src/main/java/ini/trakem2/display/Display3D.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/DisplayCanvas.java
+++ b/src/main/java/ini/trakem2/display/DisplayCanvas.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/DisplayNavigator.java
+++ b/src/main/java/ini/trakem2/display/DisplayNavigator.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Displayable.java
+++ b/src/main/java/ini/trakem2/display/Displayable.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/DisplayableChooser.java
+++ b/src/main/java/ini/trakem2/display/DisplayableChooser.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/DisplayablePanel.java
+++ b/src/main/java/ini/trakem2/display/DisplayablePanel.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Dissector.java
+++ b/src/main/java/ini/trakem2/display/Dissector.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/DoStep.java
+++ b/src/main/java/ini/trakem2/display/DoStep.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/FakeImagePlus.java
+++ b/src/main/java/ini/trakem2/display/FakeImagePlus.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/FakeImageWindow.java
+++ b/src/main/java/ini/trakem2/display/FakeImageWindow.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/FreeHandProfile.java
+++ b/src/main/java/ini/trakem2/display/FreeHandProfile.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/GroupingMode.java
+++ b/src/main/java/ini/trakem2/display/GroupingMode.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/ImageData.java
+++ b/src/main/java/ini/trakem2/display/ImageData.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/ImageJCommandListener.java
+++ b/src/main/java/ini/trakem2/display/ImageJCommandListener.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Layer.java
+++ b/src/main/java/ini/trakem2/display/Layer.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/LayerPanel.java
+++ b/src/main/java/ini/trakem2/display/LayerPanel.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/LayerSet.java
+++ b/src/main/java/ini/trakem2/display/LayerSet.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/LayerSet.java
+++ b/src/main/java/ini/trakem2/display/LayerSet.java
@@ -1148,13 +1148,72 @@ public final class LayerSet extends Displayable implements Bucketable { // Displ
 	}
 
 	private static java.lang.reflect.Field sbvalue = null;
+	private static java.lang.reflect.Field sbcoder = null;
+	private static final ThreadLocal<char[]> sbCharBuffer = ThreadLocal.withInitial(() -> new char[1024]);
 	static {
 		try {
-			sbvalue = StringBuilder.class.getSuperclass().getDeclaredField("value");
+			final Class<?> asb = StringBuilder.class.getSuperclass();
+			sbvalue = asb.getDeclaredField("value");
 			sbvalue.setAccessible(true);
+			try {
+				sbcoder = asb.getDeclaredField("coder");
+				sbcoder.setAccessible(true);
+			} catch (NoSuchFieldException ignored) {
+				// Older JVMs expose char[] directly; coder field absent.
+			}
 		} catch (Exception e) {
 			IJError.print(e);
 		}
+	}
+
+	private static char[] ensureCharBuffer(final int length) {
+		char[] buffer = sbCharBuffer.get();
+		if (buffer.length < length) {
+			buffer = new char[length];
+			sbCharBuffer.set(buffer);
+		}
+		return buffer;
+	}
+
+	private static void writeStringBuilder(final java.io.Writer writer, final StringBuilder builder) throws java.io.IOException {
+		if (null == sbvalue) {
+			writer.write(builder.toString());
+			return;
+		}
+		try {
+			final Object value = sbvalue.get(builder);
+			final int length = builder.length();
+			if (value instanceof char[]) {
+				writer.write((char[]) value, 0, length);
+				return;
+			}
+			if (value instanceof byte[]) {
+				if (null == sbcoder) {
+					writer.write(builder.toString());
+					return;
+				}
+				final byte[] bytes = (byte[]) value;
+				final char[] chars = ensureCharBuffer(length);
+				final byte coder = sbcoder.getByte(builder);
+				if (0 == coder) { // LATIN1
+					for (int i = 0; i < length; i++) {
+						chars[i] = (char) (bytes[i] & 0xFF);
+					}
+				} else { // UTF16
+					int bi = 0;
+					for (int i = 0; i < length; i++) {
+						final int lo = bytes[bi++] & 0xFF;
+						final int hi = bytes[bi++] & 0xFF;
+						chars[i] = (char) (lo | (hi << 8));
+					}
+				}
+				writer.write(chars, 0, length);
+				return;
+			}
+		} catch (IllegalAccessException e) {
+			IJError.print(e);
+		}
+		writer.write(builder.toString());
 	}
 
 	public void exportXML(final java.io.Writer writer, final String indent, final XMLOptions options) throws Exception {
@@ -1196,11 +1255,7 @@ public final class LayerSet extends Displayable implements Bucketable { // Displ
 			       .append(in).append("/>\n")
 			;
 		}
-		if (null == sbvalue) {
-			writer.write(sb_body.toString());
-		} else {
-			writer.write((char[])sbvalue.get(sb_body), 0, sb_body.length()); // avoid making a copy of the array
-		}
+		writeStringBuilder(writer, sb_body);
 		// Count objects
 		int done = 0;
 		int total = 0;
@@ -1213,11 +1268,7 @@ public final class LayerSet extends Displayable implements Bucketable { // Displ
 			for (final ZDisplayable zd : al_zdispl) {
 				sb_body.setLength(0);
 				zd.exportXML(sb_body, in, options);
-				if (null == sbvalue) {
-					writer.write(sb_body.toString()); // each separately, for they can be huge
-				} else {
-					writer.write((char[])sbvalue.get(sb_body), 0, sb_body.length()); // avoid making a copy of the array
-				}
+				writeStringBuilder(writer, sb_body); // each separately, for they can be huge
 			}
 			done += al_zdispl.size();
 			Utils.showProgress(done / (double)total);
@@ -1228,11 +1279,7 @@ public final class LayerSet extends Displayable implements Bucketable { // Displ
 			for (final Layer la : al_layers) {
 				sb_body.setLength(0);
 				la.exportXML(sb_body, in, options);
-				if (null == sbvalue) {
-					writer.write(sb_body.toString());
-				} else {
-					writer.write((char[])sbvalue.get(sb_body), 0, sb_body.length()); // avoid making a copy of the array
-				}
+				writeStringBuilder(writer, sb_body);
 				done += la.getDisplayableList().size();
 				Utils.showProgress(done / (double)total);
 			}
@@ -1240,11 +1287,7 @@ public final class LayerSet extends Displayable implements Bucketable { // Displ
 		sb_body.setLength(0);
 		if (sb_body.length() > 0) {
 			super.restXML(sb_body, in, options);
-			if (null == sbvalue) {
-				writer.write(sb_body.toString());
-			} else {
-				writer.write((char[])sbvalue.get(sb_body), 0, sb_body.length()); // avoid making a copy of the array
-			}
+			writeStringBuilder(writer, sb_body);
 		}
 		writer.write(indent + "</t2_layer_set>\n");
 	}

--- a/src/main/java/ini/trakem2/display/Line3D.java
+++ b/src/main/java/ini/trakem2/display/Line3D.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/ManualAlignMode.java
+++ b/src/main/java/ini/trakem2/display/ManualAlignMode.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/MipMapImage.java
+++ b/src/main/java/ini/trakem2/display/MipMapImage.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Mode.java
+++ b/src/main/java/ini/trakem2/display/Mode.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Node.java
+++ b/src/main/java/ini/trakem2/display/Node.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/NonLinearTransformMode.java
+++ b/src/main/java/ini/trakem2/display/NonLinearTransformMode.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Overlay.java
+++ b/src/main/java/ini/trakem2/display/Overlay.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Paintable.java
+++ b/src/main/java/ini/trakem2/display/Paintable.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Patch.java
+++ b/src/main/java/ini/trakem2/display/Patch.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Pipe.java
+++ b/src/main/java/ini/trakem2/display/Pipe.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Polyline.java
+++ b/src/main/java/ini/trakem2/display/Polyline.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Profile.java
+++ b/src/main/java/ini/trakem2/display/Profile.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Region.java
+++ b/src/main/java/ini/trakem2/display/Region.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/RollingPanel.java
+++ b/src/main/java/ini/trakem2/display/RollingPanel.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/SNTFunctions.java
+++ b/src/main/java/ini/trakem2/display/SNTFunctions.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Selection.java
+++ b/src/main/java/ini/trakem2/display/Selection.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/SnapshotPanel.java
+++ b/src/main/java/ini/trakem2/display/SnapshotPanel.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Stack.java
+++ b/src/main/java/ini/trakem2/display/Stack.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Tag.java
+++ b/src/main/java/ini/trakem2/display/Tag.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Taggable.java
+++ b/src/main/java/ini/trakem2/display/Taggable.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/TransformationStep.java
+++ b/src/main/java/ini/trakem2/display/TransformationStep.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Tree.java
+++ b/src/main/java/ini/trakem2/display/Tree.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/TreeConnectorsView.java
+++ b/src/main/java/ini/trakem2/display/TreeConnectorsView.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/Treeline.java
+++ b/src/main/java/ini/trakem2/display/Treeline.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/VectorData.java
+++ b/src/main/java/ini/trakem2/display/VectorData.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/VectorDataTransform.java
+++ b/src/main/java/ini/trakem2/display/VectorDataTransform.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/YesNoDialog.java
+++ b/src/main/java/ini/trakem2/display/YesNoDialog.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/ZDisplayable.java
+++ b/src/main/java/ini/trakem2/display/ZDisplayable.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/d3d/ControlClickBehavior.java
+++ b/src/main/java/ini/trakem2/display/d3d/ControlClickBehavior.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/d3d/Display3DGUI.java
+++ b/src/main/java/ini/trakem2/display/d3d/Display3DGUI.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/graphics/AddARGBComposite.java
+++ b/src/main/java/ini/trakem2/display/graphics/AddARGBComposite.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/graphics/ColorYCbCrComposite.java
+++ b/src/main/java/ini/trakem2/display/graphics/ColorYCbCrComposite.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/graphics/DefaultGraphicsSource.java
+++ b/src/main/java/ini/trakem2/display/graphics/DefaultGraphicsSource.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/graphics/DifferenceARGBComposite.java
+++ b/src/main/java/ini/trakem2/display/graphics/DifferenceARGBComposite.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/graphics/GraphicsSource.java
+++ b/src/main/java/ini/trakem2/display/graphics/GraphicsSource.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/graphics/MultiplyARGBComposite.java
+++ b/src/main/java/ini/trakem2/display/graphics/MultiplyARGBComposite.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/graphics/SubtractARGBComposite.java
+++ b/src/main/java/ini/trakem2/display/graphics/SubtractARGBComposite.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/graphics/TestGraphicsSource.java
+++ b/src/main/java/ini/trakem2/display/graphics/TestGraphicsSource.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/inspect/InspectPatchTrianglesMode.java
+++ b/src/main/java/ini/trakem2/display/inspect/InspectPatchTrianglesMode.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/inspect/ShapeProxy.java
+++ b/src/main/java/ini/trakem2/display/inspect/ShapeProxy.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/paint/USHORTPaint.java
+++ b/src/main/java/ini/trakem2/display/paint/USHORTPaint.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/display/paint/USHORTPaintContext.java
+++ b/src/main/java/ini/trakem2/display/paint/USHORTPaintContext.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/BinaryInterpolation2D.java
+++ b/src/main/java/ini/trakem2/imaging/BinaryInterpolation2D.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/Blending.java
+++ b/src/main/java/ini/trakem2/imaging/Blending.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/ContrastEnhancerWrapper.java
+++ b/src/main/java/ini/trakem2/imaging/ContrastEnhancerWrapper.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/ContrastPlot.java
+++ b/src/main/java/ini/trakem2/imaging/ContrastPlot.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/FastIntegralImage.java
+++ b/src/main/java/ini/trakem2/imaging/FastIntegralImage.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/FloatProcessorT2.java
+++ b/src/main/java/ini/trakem2/imaging/FloatProcessorT2.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/ImagePreprocessor.java
+++ b/src/main/java/ini/trakem2/imaging/ImagePreprocessor.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/IntegralHistogram2d.java
+++ b/src/main/java/ini/trakem2/imaging/IntegralHistogram2d.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/LayerStack.java
+++ b/src/main/java/ini/trakem2/imaging/LayerStack.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/LazyVirtualStack.java
+++ b/src/main/java/ini/trakem2/imaging/LazyVirtualStack.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/P.java
+++ b/src/main/java/ini/trakem2/imaging/P.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/PatchStack.java
+++ b/src/main/java/ini/trakem2/imaging/PatchStack.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/PhaseCorrelationCalculator.java
+++ b/src/main/java/ini/trakem2/imaging/PhaseCorrelationCalculator.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/Segmentation.java
+++ b/src/main/java/ini/trakem2/imaging/Segmentation.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/StitchingTEM.java
+++ b/src/main/java/ini/trakem2/imaging/StitchingTEM.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/CLAHE.java
+++ b/src/main/java/ini/trakem2/imaging/filters/CLAHE.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/CorrectBackground.java
+++ b/src/main/java/ini/trakem2/imaging/filters/CorrectBackground.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/DefaultMinAndMax.java
+++ b/src/main/java/ini/trakem2/imaging/filters/DefaultMinAndMax.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/EnhanceContrast.java
+++ b/src/main/java/ini/trakem2/imaging/filters/EnhanceContrast.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/EqualizeHistogram.java
+++ b/src/main/java/ini/trakem2/imaging/filters/EqualizeHistogram.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/FilterEditor.java
+++ b/src/main/java/ini/trakem2/imaging/filters/FilterEditor.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/GaussianBlur.java
+++ b/src/main/java/ini/trakem2/imaging/filters/GaussianBlur.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/IFilter.java
+++ b/src/main/java/ini/trakem2/imaging/filters/IFilter.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/Invert.java
+++ b/src/main/java/ini/trakem2/imaging/filters/Invert.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/LUTBlue.java
+++ b/src/main/java/ini/trakem2/imaging/filters/LUTBlue.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/LUTCustom.java
+++ b/src/main/java/ini/trakem2/imaging/filters/LUTCustom.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/LUTCyan.java
+++ b/src/main/java/ini/trakem2/imaging/filters/LUTCyan.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/LUTGreen.java
+++ b/src/main/java/ini/trakem2/imaging/filters/LUTGreen.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/LUTMagenta.java
+++ b/src/main/java/ini/trakem2/imaging/filters/LUTMagenta.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/LUTOrange.java
+++ b/src/main/java/ini/trakem2/imaging/filters/LUTOrange.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/LUTRed.java
+++ b/src/main/java/ini/trakem2/imaging/filters/LUTRed.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/LUTYellow.java
+++ b/src/main/java/ini/trakem2/imaging/filters/LUTYellow.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/Normalize.java
+++ b/src/main/java/ini/trakem2/imaging/filters/Normalize.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/NormalizeLocalContrast.java
+++ b/src/main/java/ini/trakem2/imaging/filters/NormalizeLocalContrast.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/RankFilter.java
+++ b/src/main/java/ini/trakem2/imaging/filters/RankFilter.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/ResetMinAndMax.java
+++ b/src/main/java/ini/trakem2/imaging/filters/ResetMinAndMax.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/RobustNormalizeLocalContrast.java
+++ b/src/main/java/ini/trakem2/imaging/filters/RobustNormalizeLocalContrast.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/SubtractBackground.java
+++ b/src/main/java/ini/trakem2/imaging/filters/SubtractBackground.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/imaging/filters/ValueToNoise.java
+++ b/src/main/java/ini/trakem2/imaging/filters/ValueToNoise.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/io/AmiraImporter.java
+++ b/src/main/java/ini/trakem2/io/AmiraImporter.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/io/CoordinateTransformXML.java
+++ b/src/main/java/ini/trakem2/io/CoordinateTransformXML.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/io/ImageFileFilter.java
+++ b/src/main/java/ini/trakem2/io/ImageFileFilter.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/io/ImageFileHeader.java
+++ b/src/main/java/ini/trakem2/io/ImageFileHeader.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/io/ImageSaver.java
+++ b/src/main/java/ini/trakem2/io/ImageSaver.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/io/LoggingInputStream.java
+++ b/src/main/java/ini/trakem2/io/LoggingInputStream.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/io/NeuroML.java
+++ b/src/main/java/ini/trakem2/io/NeuroML.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/io/RagMipMaps.java
+++ b/src/main/java/ini/trakem2/io/RagMipMaps.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/io/RawMipMaps.java
+++ b/src/main/java/ini/trakem2/io/RawMipMaps.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/io/XMLFileFilter.java
+++ b/src/main/java/ini/trakem2/io/XMLFileFilter.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/parallel/CountingTaskFactory.java
+++ b/src/main/java/ini/trakem2/parallel/CountingTaskFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/parallel/DefaultExecutorProvider.java
+++ b/src/main/java/ini/trakem2/parallel/DefaultExecutorProvider.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/parallel/ExecutorProvider.java
+++ b/src/main/java/ini/trakem2/parallel/ExecutorProvider.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/parallel/ParallelMapping.java
+++ b/src/main/java/ini/trakem2/parallel/ParallelMapping.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/parallel/Process.java
+++ b/src/main/java/ini/trakem2/parallel/Process.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/parallel/TaskFactory.java
+++ b/src/main/java/ini/trakem2/parallel/TaskFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/persistence/Cache.java
+++ b/src/main/java/ini/trakem2/persistence/Cache.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/persistence/DBLoader.java
+++ b/src/main/java/ini/trakem2/persistence/DBLoader.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/persistence/DBObject.java
+++ b/src/main/java/ini/trakem2/persistence/DBObject.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/persistence/DownsamplerMipMaps.java
+++ b/src/main/java/ini/trakem2/persistence/DownsamplerMipMaps.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/persistence/ExportMultilevelTiles.java
+++ b/src/main/java/ini/trakem2/persistence/ExportMultilevelTiles.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/persistence/FSLoader.java
+++ b/src/main/java/ini/trakem2/persistence/FSLoader.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/persistence/FilePathRepair.java
+++ b/src/main/java/ini/trakem2/persistence/FilePathRepair.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/persistence/ImageBytes.java
+++ b/src/main/java/ini/trakem2/persistence/ImageBytes.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/persistence/IntegralImageMipMaps.java
+++ b/src/main/java/ini/trakem2/persistence/IntegralImageMipMaps.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/persistence/Loader.java
+++ b/src/main/java/ini/trakem2/persistence/Loader.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/persistence/ProjectTiler.java
+++ b/src/main/java/ini/trakem2/persistence/ProjectTiler.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/persistence/StaleFiles.java
+++ b/src/main/java/ini/trakem2/persistence/StaleFiles.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/persistence/TMLHandler.java
+++ b/src/main/java/ini/trakem2/persistence/TMLHandler.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/persistence/XMLOptions.java
+++ b/src/main/java/ini/trakem2/persistence/XMLOptions.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/plugin/TPlugIn.java
+++ b/src/main/java/ini/trakem2/plugin/TPlugIn.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/scripting/PatchScript.java
+++ b/src/main/java/ini/trakem2/scripting/PatchScript.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/tree/AbstractTreeTransferHandler.java
+++ b/src/main/java/ini/trakem2/tree/AbstractTreeTransferHandler.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/tree/DNDTree.java
+++ b/src/main/java/ini/trakem2/tree/DNDTree.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/tree/DTDParser.java
+++ b/src/main/java/ini/trakem2/tree/DTDParser.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/tree/DefaultTreeTransferHandler.java
+++ b/src/main/java/ini/trakem2/tree/DefaultTreeTransferHandler.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/tree/LayerThing.java
+++ b/src/main/java/ini/trakem2/tree/LayerThing.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/tree/LayerTree.java
+++ b/src/main/java/ini/trakem2/tree/LayerTree.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/tree/ProjectThing.java
+++ b/src/main/java/ini/trakem2/tree/ProjectThing.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/tree/ProjectTree.java
+++ b/src/main/java/ini/trakem2/tree/ProjectTree.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/tree/RenameThingStep.java
+++ b/src/main/java/ini/trakem2/tree/RenameThingStep.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/tree/TemplateThing.java
+++ b/src/main/java/ini/trakem2/tree/TemplateThing.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/tree/TemplateTree.java
+++ b/src/main/java/ini/trakem2/tree/TemplateTree.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/tree/Thing.java
+++ b/src/main/java/ini/trakem2/tree/Thing.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/tree/TitledThing.java
+++ b/src/main/java/ini/trakem2/tree/TitledThing.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/tree/TrakEM2MLParser.java
+++ b/src/main/java/ini/trakem2/tree/TrakEM2MLParser.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/tree/TransferableNode.java
+++ b/src/main/java/ini/trakem2/tree/TransferableNode.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/AreaUtils.java
+++ b/src/main/java/ini/trakem2/utils/AreaUtils.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/BigBrother.java
+++ b/src/main/java/ini/trakem2/utils/BigBrother.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/Bureaucrat.java
+++ b/src/main/java/ini/trakem2/utils/Bureaucrat.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/CachingThread.java
+++ b/src/main/java/ini/trakem2/utils/CachingThread.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/CircularSequence.java
+++ b/src/main/java/ini/trakem2/utils/CircularSequence.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/DNDInsertImage.java
+++ b/src/main/java/ini/trakem2/utils/DNDInsertImage.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/Dispatcher.java
+++ b/src/main/java/ini/trakem2/utils/Dispatcher.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/FieldMapView.java
+++ b/src/main/java/ini/trakem2/utils/FieldMapView.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/Filter.java
+++ b/src/main/java/ini/trakem2/utils/Filter.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/History.java
+++ b/src/main/java/ini/trakem2/utils/History.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/IJError.java
+++ b/src/main/java/ini/trakem2/utils/IJError.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/ImgLibVolume.java
+++ b/src/main/java/ini/trakem2/utils/ImgLibVolume.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/IntegerField.java
+++ b/src/main/java/ini/trakem2/utils/IntegerField.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/Lock.java
+++ b/src/main/java/ini/trakem2/utils/Lock.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/M.java
+++ b/src/main/java/ini/trakem2/utils/M.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/MCCube.java
+++ b/src/main/java/ini/trakem2/utils/MCCube.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/MCTriangulator.java
+++ b/src/main/java/ini/trakem2/utils/MCTriangulator.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/Merger.java
+++ b/src/main/java/ini/trakem2/utils/Merger.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/Montage.java
+++ b/src/main/java/ini/trakem2/utils/Montage.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/Operation.java
+++ b/src/main/java/ini/trakem2/utils/Operation.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/OptionPanel.java
+++ b/src/main/java/ini/trakem2/utils/OptionPanel.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/ProjectToolbar.java
+++ b/src/main/java/ini/trakem2/utils/ProjectToolbar.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/ReconstructArea.java
+++ b/src/main/java/ini/trakem2/utils/ReconstructArea.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/RedPhone.java
+++ b/src/main/java/ini/trakem2/utils/RedPhone.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/Render.java
+++ b/src/main/java/ini/trakem2/utils/Render.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/Saver.java
+++ b/src/main/java/ini/trakem2/utils/Saver.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/Search.java
+++ b/src/main/java/ini/trakem2/utils/Search.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/StdOutWindow.java
+++ b/src/main/java/ini/trakem2/utils/StdOutWindow.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/StopWatch.java
+++ b/src/main/java/ini/trakem2/utils/StopWatch.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/TaskOnEDT.java
+++ b/src/main/java/ini/trakem2/utils/TaskOnEDT.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/TypedHashMap.java
+++ b/src/main/java/ini/trakem2/utils/TypedHashMap.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/Utils.java
+++ b/src/main/java/ini/trakem2/utils/Utils.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/Vector3.java
+++ b/src/main/java/ini/trakem2/utils/Vector3.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/ini/trakem2/utils/Worker.java
+++ b/src/main/java/ini/trakem2/utils/Worker.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/lenscorrection/DistortionCorrectionTask.java
+++ b/src/main/java/lenscorrection/DistortionCorrectionTask.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/lenscorrection/Distortion_Correction.java
+++ b/src/main/java/lenscorrection/Distortion_Correction.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/lenscorrection/NonLinearTransform.java
+++ b/src/main/java/lenscorrection/NonLinearTransform.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/lenscorrection/PolynomialModel2D.java
+++ b/src/main/java/lenscorrection/PolynomialModel2D.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpi/fruitfly/general/ArrayConverter.java
+++ b/src/main/java/mpi/fruitfly/general/ArrayConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpi/fruitfly/general/ImageArrayConverter.java
+++ b/src/main/java/mpi/fruitfly/general/ImageArrayConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpi/fruitfly/general/MultiThreading.java
+++ b/src/main/java/mpi/fruitfly/general/MultiThreading.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpi/fruitfly/math/General.java
+++ b/src/main/java/mpi/fruitfly/math/General.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpi/fruitfly/math/Quicksortable.java
+++ b/src/main/java/mpi/fruitfly/math/Quicksortable.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpi/fruitfly/math/datastructures/FloatArray.java
+++ b/src/main/java/mpi/fruitfly/math/datastructures/FloatArray.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpi/fruitfly/math/datastructures/FloatArray2D.java
+++ b/src/main/java/mpi/fruitfly/math/datastructures/FloatArray2D.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpi/fruitfly/math/datastructures/FloatArray3D.java
+++ b/src/main/java/mpi/fruitfly/math/datastructures/FloatArray3D.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpi/fruitfly/math/datastructures/FloatArray4D.java
+++ b/src/main/java/mpi/fruitfly/math/datastructures/FloatArray4D.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpi/fruitfly/registration/CrossCorrelation2D.java
+++ b/src/main/java/mpi/fruitfly/registration/CrossCorrelation2D.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpi/fruitfly/registration/ImageFilter.java
+++ b/src/main/java/mpi/fruitfly/registration/ImageFilter.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/align/AbstractAffineTile2D.java
+++ b/src/main/java/mpicbg/trakem2/align/AbstractAffineTile2D.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/align/AbstractLayerAlignmentParam.java
+++ b/src/main/java/mpicbg/trakem2/align/AbstractLayerAlignmentParam.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/align/AffineTile2D.java
+++ b/src/main/java/mpicbg/trakem2/align/AffineTile2D.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/align/Align.java
+++ b/src/main/java/mpicbg/trakem2/align/Align.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/align/AlignLayersTask.java
+++ b/src/main/java/mpicbg/trakem2/align/AlignLayersTask.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/align/AlignTask.java
+++ b/src/main/java/mpicbg/trakem2/align/AlignTask.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/align/AlignmentUtils.java
+++ b/src/main/java/mpicbg/trakem2/align/AlignmentUtils.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/align/ElasticLayerAlignment.java
+++ b/src/main/java/mpicbg/trakem2/align/ElasticLayerAlignment.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/align/ElasticMontage.java
+++ b/src/main/java/mpicbg/trakem2/align/ElasticMontage.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/align/GenericAffineTile2D.java
+++ b/src/main/java/mpicbg/trakem2/align/GenericAffineTile2D.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/align/RegularizedAffineLayerAlignment.java
+++ b/src/main/java/mpicbg/trakem2/align/RegularizedAffineLayerAlignment.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/align/RigidTile2D.java
+++ b/src/main/java/mpicbg/trakem2/align/RigidTile2D.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/align/SimilarityTile2D.java
+++ b/src/main/java/mpicbg/trakem2/align/SimilarityTile2D.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/align/TileConfiguration.java
+++ b/src/main/java/mpicbg/trakem2/align/TileConfiguration.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/align/TranslationTile2D.java
+++ b/src/main/java/mpicbg/trakem2/align/TranslationTile2D.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/align/Util.java
+++ b/src/main/java/mpicbg/trakem2/align/Util.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/align/concurrent/BlockMatchPairCallable.java
+++ b/src/main/java/mpicbg/trakem2/align/concurrent/BlockMatchPairCallable.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/transform/ExportARGB.java
+++ b/src/main/java/mpicbg/trakem2/transform/ExportARGB.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/transform/ExportBestFlatImage.java
+++ b/src/main/java/mpicbg/trakem2/transform/ExportBestFlatImage.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/transform/ExportUnsignedByte.java
+++ b/src/main/java/mpicbg/trakem2/transform/ExportUnsignedByte.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/transform/ExportUnsignedShort.java
+++ b/src/main/java/mpicbg/trakem2/transform/ExportUnsignedShort.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/mpicbg/trakem2/util/RobustNormalizeLocalContrast.java
+++ b/src/main/java/mpicbg/trakem2/util/RobustNormalizeLocalContrast.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/intensity/LinearIntensityMap.java
+++ b/src/main/java/org/janelia/intensity/LinearIntensityMap.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/intensity/MatchIntensities.java
+++ b/src/main/java/org/janelia/intensity/MatchIntensities.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/intensity/PointMatchFilter.java
+++ b/src/main/java/org/janelia/intensity/PointMatchFilter.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/intensity/RansacRegressionFilter.java
+++ b/src/main/java/org/janelia/intensity/RansacRegressionFilter.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/intensity/RansacRegressionReduceFilter.java
+++ b/src/main/java/org/janelia/intensity/RansacRegressionReduceFilter.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/intensity/Render.java
+++ b/src/main/java/org/janelia/intensity/Render.java
@@ -2,7 +2,7 @@
  * #%L
  * TrakEM2 plugin for ImageJ.
  * %%
- * Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/resources/img/link.svg
+++ b/src/main/resources/img/link.svg
@@ -3,7 +3,7 @@
   #%L
   TrakEM2 plugin for ImageJ.
   %%
-  Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+  Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
   %%
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as

--- a/src/main/resources/img/lock.svg
+++ b/src/main/resources/img/lock.svg
@@ -3,7 +3,7 @@
   #%L
   TrakEM2 plugin for ImageJ.
   %%
-  Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+  Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
   %%
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as

--- a/src/main/resources/img/visibility.svg
+++ b/src/main/resources/img/visibility.svg
@@ -3,7 +3,7 @@
   #%L
   TrakEM2 plugin for ImageJ.
   %%
-  Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+  Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
   %%
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as

--- a/src/main/resources/plugins.config
+++ b/src/main/resources/plugins.config
@@ -2,7 +2,7 @@
 # #%L
 # TrakEM2 plugin for ImageJ.
 # %%
-# Copyright (C) 2005 - 2024 Albert Cardona, Stephan Saalfeld and others.
+# Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
 # %%
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as

--- a/src/test/java/ini/trakem2/display/LayerSetWriteStringBuilderTest.java
+++ b/src/test/java/ini/trakem2/display/LayerSetWriteStringBuilderTest.java
@@ -1,3 +1,24 @@
+/*-
+ * #%L
+ * TrakEM2 plugin for ImageJ.
+ * %%
+ * Copyright (C) 2005 - 2025 Albert Cardona, Stephan Saalfeld and others.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
 package ini.trakem2.display;
 
 import static org.junit.Assert.*;

--- a/src/test/java/ini/trakem2/display/LayerSetWriteStringBuilderTest.java
+++ b/src/test/java/ini/trakem2/display/LayerSetWriteStringBuilderTest.java
@@ -1,0 +1,158 @@
+package ini.trakem2.display;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeNotNull;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Exercises {@link LayerSet#writeStringBuilder(java.io.Writer, StringBuilder)}
+ * across the different runtime layouts seen in StringBuilder.
+ */
+public class LayerSetWriteStringBuilderTest {
+
+	private Field sbvalueField;
+	private Field sbcoderField;
+	private Method writeMethod;
+
+	private Object originalSbvalue;
+	private Object originalSbcoder;
+
+	@Before
+	public void setUp() throws Exception {
+		sbvalueField = LayerSet.class.getDeclaredField("sbvalue");
+		sbvalueField.setAccessible(true);
+		sbcoderField = LayerSet.class.getDeclaredField("sbcoder");
+		sbcoderField.setAccessible(true);
+		writeMethod = LayerSet.class.getDeclaredMethod("writeStringBuilder", java.io.Writer.class, StringBuilder.class);
+		writeMethod.setAccessible(true);
+
+		originalSbvalue = sbvalueField.get(null);
+		originalSbcoder = sbcoderField.get(null);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		sbvalueField.set(null, originalSbvalue);
+		sbcoderField.set(null, originalSbcoder);
+	}
+
+	@Test
+	public void fallsBackWhenReflectionUnavailable() throws Exception {
+		sbvalueField.set(null, null);
+		sbcoderField.set(null, null);
+
+		RecordingWriter writer = new RecordingWriter();
+		StringBuilder builder = new StringBuilder("fallback");
+
+		invokeWrite(writer, builder);
+
+		assertTrue("Expected String-based write when reflection is disabled", writer.usedString);
+		assertFalse("Char-array path should not be used when reflection is disabled", writer.usedCharArray);
+		assertEquals(builder.toString(), writer.content());
+	}
+
+	@Test
+	public void writesLatin1BackedBuilder() throws Exception {
+		Object sbvalue = sbvalueField.get(null);
+		Object sbcoder = sbcoderField.get(null);
+		assumeNotNull(sbvalue, sbcoder);
+
+		Field coderField = (Field) sbcoder;
+		coderField.setAccessible(true);
+
+		StringBuilder builder = new StringBuilder("ascii-only");
+		byte coder = coderField.getByte(builder);
+		assertEquals("Expected LATIN1 coder", 0, coder);
+
+		RecordingWriter writer = new RecordingWriter();
+		invokeWrite(writer, builder);
+
+		assertTrue("Char-array path should be used for byte-backed builders", writer.usedCharArray);
+		assertFalse("String-based fallback should not be triggered", writer.usedString);
+		assertEquals(builder.toString(), writer.content());
+	}
+
+	@Test
+	public void writesUtf16BackedBuilder() throws Exception {
+		Object sbvalue = sbvalueField.get(null);
+		Object sbcoder = sbcoderField.get(null);
+		assumeNotNull(sbvalue, sbcoder);
+
+		Field coderField = (Field) sbcoder;
+		coderField.setAccessible(true);
+
+		StringBuilder builder = new StringBuilder();
+		builder.append('\u0101').append('\u05D0');
+		byte coder = coderField.getByte(builder);
+		assertEquals("Expected UTF16 coder", 1, coder);
+
+		RecordingWriter writer = new RecordingWriter();
+		invokeWrite(writer, builder);
+
+		assertTrue("Char-array path should be used for UTF16 byte-backed builders", writer.usedCharArray);
+		assertFalse("String-based fallback should not be triggered", writer.usedString);
+		assertEquals(builder.toString(), writer.content());
+	}
+
+	private void invokeWrite(RecordingWriter writer, StringBuilder builder) throws Exception {
+		try {
+			writeMethod.invoke(null, writer, builder);
+		} catch (InvocationTargetException e) {
+			Throwable cause = e.getCause();
+			if (cause instanceof Exception) {
+				throw (Exception) cause;
+			}
+			if (cause instanceof Error) {
+				throw (Error) cause;
+			}
+			throw new RuntimeException(cause);
+		}
+	}
+
+	private static final class RecordingWriter extends Writer {
+		private final StringBuilder out = new StringBuilder();
+		private boolean usedCharArray;
+		private boolean usedString;
+
+		@Override
+		public void write(char[] cbuf, int off, int len) {
+			usedCharArray = true;
+			out.append(cbuf, off, len);
+		}
+
+		@Override
+		public void write(int c) {
+			usedCharArray = true;
+			out.append((char) c);
+		}
+
+		@Override
+		public void write(String str, int off, int len) {
+			usedString = true;
+			out.append(str, off, off + len);
+		}
+
+		@Override
+		public void flush() throws IOException {
+			// no-op
+		}
+
+		@Override
+		public void close() throws IOException {
+			// no-op
+		}
+
+		String content() {
+			return out.toString();
+		}
+	}
+}


### PR DESCRIPTION
In Java9+ StringBuilder.value is not char[] but byte[], so projects don't export to XML.  This patch maintains the efficiency shortcut for Java 8, and 9+ and a falls back to toString() otherwise (not sure if that's necessary).

vibed with GPT-5-Codex