### PR TITLE
Removed uses of reflection that break in newer Java versions

### DIFF
--- a/src/main/java/ini/trakem2/display/Patch.java
+++ b/src/main/java/ini/trakem2/display/Patch.java
@@ -1619,7 +1619,7 @@ public final class Patch extends Displayable implements ImageData {
 			Utils.ensure(f);
 			ra = new RandomAccessFile(f, "rw");
 
-			final ImageSaver.ExposedByteArrayOutputStream ba = new ImageSaver.ExposedByteArrayOutputStream(bp.getWidth() * bp.getHeight());
+			final ByteArrayOutputStream ba = new ByteArrayOutputStream(bp.getWidth() * bp.getHeight());
 			final ZipOutputStream zos = new ZipOutputStream(ba);
 			final ImagePlus imp = new ImagePlus("mask.tif", bp); // ImageJ looks for ".tif" extension in the ZipEntry
 			zos.putNextEntry(new ZipEntry(imp.getTitle()));
@@ -1629,7 +1629,7 @@ public final class Patch extends Displayable implements ImageData {
 			zos.closeEntry();
 			zos.close();
 
-			ra.write(ba.rawBuf(), 0, ba.size());
+			ra.write(ba.toByteArray(), 0, ba.size());
 			return true;
 		} catch (final Throwable e) {
 			IJError.print(e);

--- a/src/main/java/ini/trakem2/display/Patch.java
+++ b/src/main/java/ini/trakem2/display/Patch.java
@@ -1619,7 +1619,7 @@ public final class Patch extends Displayable implements ImageData {
 			Utils.ensure(f);
 			ra = new RandomAccessFile(f, "rw");
 
-			final ByteArrayOutputStream ba = new ByteArrayOutputStream(bp.getWidth() * bp.getHeight());
+			final ImageSaver.ExposedByteArrayOutputStream ba = new ImageSaver.ExposedByteArrayOutputStream(bp.getWidth() * bp.getHeight());
 			final ZipOutputStream zos = new ZipOutputStream(ba);
 			final ImagePlus imp = new ImagePlus("mask.tif", bp); // ImageJ looks for ".tif" extension in the ZipEntry
 			zos.putNextEntry(new ZipEntry(imp.getTitle()));
@@ -1629,7 +1629,7 @@ public final class Patch extends Displayable implements ImageData {
 			zos.closeEntry();
 			zos.close();
 
-			ra.write((byte[])ImageSaver.Bbuf.get(ba), 0, ba.size());
+			ra.write(ba.rawBuf(), 0, ba.size());
 			return true;
 		} catch (final Throwable e) {
 			IJError.print(e);

--- a/src/main/java/ini/trakem2/io/ImageSaver.java
+++ b/src/main/java/ini/trakem2/io/ImageSaver.java
@@ -82,6 +82,17 @@ public class ImageSaver {
 
 	private ImageSaver() {}
 
+	/** A ByteArrayOutputStream that exposes its internal buffer, avoiding need for reflection or copying **/
+	static private final class ExposedByteArrayOutputStream extends ByteArrayOutputStream {
+		ExposedByteArrayOutputStream(final int initialSize) {
+			super(initialSize);
+		}
+		/** Returns the raw internal buffer. Valid up to size() bytes. */
+		byte[] rawBuf() {
+			return buf; // 'buf' is protected in ByteArrayOutputStream
+		}
+	}
+
 	static private final Object OBDIRS = new Object();
 
 	/** Will create parent directories if they don't exist.
@@ -224,7 +235,7 @@ public class ImageSaver {
 			BufferedImage grey = bi;
 			try {
 				writer = ImageIO.getImageWritersByFormatName("jpeg").next();
-				final ByteArrayOutputStream baos = new ByteArrayOutputStream( estimateJPEGFileSize(bi.getWidth(), bi.getHeight()) );
+				final ExposedByteArrayOutputStream baos = new ExposedByteArrayOutputStream( estimateJPEGFileSize(bi.getWidth(), bi.getHeight()) );
 				ios = ImageIO.createImageOutputStream(baos);
 				writer.setOutput(ios);
 				ImageWriteParam param = writer.getDefaultWriteParam();
@@ -246,7 +257,7 @@ public class ImageSaver {
 				try {
 					// Now write to disk in the fastest way possible
 					final RandomAccessFile ra = new RandomAccessFile(new File(path), "rw");
-					final ByteBuffer bb = ByteBuffer.wrap((byte[])Bbuf.get(baos), 0, baos.size());
+					final ByteBuffer bb = ByteBuffer.wrap(baos.rawBuf(), 0, baos.size());
 					ch = ra.getChannel();
 					while (bb.hasRemaining()) {
 						ch.write(bb);
@@ -467,18 +478,6 @@ public class ImageSaver {
 		sb.append((char)0);
 		return new String(sb);
 	}
-
-	static public final Field Bbuf;
-	static {
-		Field b = null;
-		try {
-			b = ByteArrayOutputStream.class.getDeclaredField("buf");
-			b.setAccessible(true);
-		} catch (Exception e) {
-			IJError.print(e);
-		}
-		Bbuf = b;
-	}
 	
 	/** Based on EM images of neuropils with outside alpha masks.
 	 * Fitted a polynomial on the length of file vs area size. */
@@ -501,7 +500,7 @@ public class ImageSaver {
 					//((JPEGImageWriteParam)iwp).setProgressiveMode(JPEGImageWriteParam.MODE_DISABLED);
 					//((JPEGImageWriteParam)iwp).
 					//
-					final ByteArrayOutputStream baos = new ByteArrayOutputStream( estimateJPEGFileSize(awt.getWidth(), awt.getHeight()) );
+					final ExposedByteArrayOutputStream baos = new ExposedByteArrayOutputStream( estimateJPEGFileSize(awt.getWidth(), awt.getHeight()) );
 					ImageOutputStream ios = ImageIO.createImageOutputStream(baos);
 					RandomAccessFile ra = null;
 					FileChannel ch = null;
@@ -510,7 +509,7 @@ public class ImageSaver {
 						writer.write(writer.getDefaultStreamMetadata(iwp), new IIOImage(awt, null, null), iwp);
 						// Now write to disk in the fastest way possible
 						ra = new RandomAccessFile(new File(path), "rw");
-						final ByteBuffer bb = ByteBuffer.wrap((byte[])Bbuf.get(baos), 0, baos.size());
+						final ByteBuffer bb = ByteBuffer.wrap(baos.rawBuf(), 0, baos.size());
 						ch = ra.getChannel();
 						while (bb.hasRemaining()) {
 							ch.write(bb);

--- a/src/main/java/ini/trakem2/io/ImageSaver.java
+++ b/src/main/java/ini/trakem2/io/ImageSaver.java
@@ -61,7 +61,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
-import java.lang.reflect.Field;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -81,17 +80,6 @@ import javax.media.jai.PlanarImage;
 public class ImageSaver {
 
 	private ImageSaver() {}
-
-	/** A ByteArrayOutputStream that exposes its internal buffer, avoiding need for reflection or copying **/
-	static public final class ExposedByteArrayOutputStream extends ByteArrayOutputStream {
-		public ExposedByteArrayOutputStream(final int initialSize) {
-			super(initialSize);
-		}
-		/** Returns the raw internal buffer. Valid up to size() bytes. */
-		public byte[] rawBuf() {
-			return buf; // 'buf' is protected in ByteArrayOutputStream
-		}
-	}
 
 	static private final Object OBDIRS = new Object();
 
@@ -235,7 +223,7 @@ public class ImageSaver {
 			BufferedImage grey = bi;
 			try {
 				writer = ImageIO.getImageWritersByFormatName("jpeg").next();
-				final ExposedByteArrayOutputStream baos = new ExposedByteArrayOutputStream( estimateJPEGFileSize(bi.getWidth(), bi.getHeight()) );
+				final ByteArrayOutputStream baos = new ByteArrayOutputStream( estimateJPEGFileSize(bi.getWidth(), bi.getHeight()) );
 				ios = ImageIO.createImageOutputStream(baos);
 				writer.setOutput(ios);
 				ImageWriteParam param = writer.getDefaultWriteParam();
@@ -257,7 +245,7 @@ public class ImageSaver {
 				try {
 					// Now write to disk in the fastest way possible
 					final RandomAccessFile ra = new RandomAccessFile(new File(path), "rw");
-					final ByteBuffer bb = ByteBuffer.wrap(baos.rawBuf(), 0, baos.size());
+					final ByteBuffer bb = ByteBuffer.wrap(baos.toByteArray(), 0, baos.size());
 					ch = ra.getChannel();
 					while (bb.hasRemaining()) {
 						ch.write(bb);
@@ -500,7 +488,7 @@ public class ImageSaver {
 					//((JPEGImageWriteParam)iwp).setProgressiveMode(JPEGImageWriteParam.MODE_DISABLED);
 					//((JPEGImageWriteParam)iwp).
 					//
-					final ExposedByteArrayOutputStream baos = new ExposedByteArrayOutputStream( estimateJPEGFileSize(awt.getWidth(), awt.getHeight()) );
+					final ByteArrayOutputStream baos = new ByteArrayOutputStream( estimateJPEGFileSize(awt.getWidth(), awt.getHeight()) );
 					ImageOutputStream ios = ImageIO.createImageOutputStream(baos);
 					RandomAccessFile ra = null;
 					FileChannel ch = null;
@@ -509,7 +497,7 @@ public class ImageSaver {
 						writer.write(writer.getDefaultStreamMetadata(iwp), new IIOImage(awt, null, null), iwp);
 						// Now write to disk in the fastest way possible
 						ra = new RandomAccessFile(new File(path), "rw");
-						final ByteBuffer bb = ByteBuffer.wrap(baos.rawBuf(), 0, baos.size());
+						final ByteBuffer bb = ByteBuffer.wrap(baos.toByteArray(), 0, baos.size());
 						ch = ra.getChannel();
 						while (bb.hasRemaining()) {
 							ch.write(bb);

--- a/src/main/java/ini/trakem2/io/ImageSaver.java
+++ b/src/main/java/ini/trakem2/io/ImageSaver.java
@@ -83,12 +83,12 @@ public class ImageSaver {
 	private ImageSaver() {}
 
 	/** A ByteArrayOutputStream that exposes its internal buffer, avoiding need for reflection or copying **/
-	static private final class ExposedByteArrayOutputStream extends ByteArrayOutputStream {
-		ExposedByteArrayOutputStream(final int initialSize) {
+	static public final class ExposedByteArrayOutputStream extends ByteArrayOutputStream {
+		public ExposedByteArrayOutputStream(final int initialSize) {
 			super(initialSize);
 		}
 		/** Returns the raw internal buffer. Valid up to size() bytes. */
-		byte[] rawBuf() {
+		public byte[] rawBuf() {
 			return buf; // 'buf' is protected in ByteArrayOutputStream
 		}
 	}

--- a/src/main/java/ini/trakem2/io/RagMipMaps.java
+++ b/src/main/java/ini/trakem2/io/RagMipMaps.java
@@ -98,12 +98,12 @@ public final class RagMipMaps
 					ra.write(b[i]);
 				}
 				// Now write a compressed alpha channel:
-				final ImageSaver.ExposedByteArrayOutputStream ba = new ImageSaver.ExposedByteArrayOutputStream(b.length);
+				final ByteArrayOutputStream ba = new ByteArrayOutputStream(b.length);
 				final DeflaterOutputStream def = new DeflaterOutputStream(ba, new Deflater(4, false), 1024);
 				def.write(b[b.length-1]);
 				def.finish();
 				def.flush(); // likely not needed
-				ra.write(ba.rawBuf(), 0, ba.size());
+				ra.write(ba.toByteArray(), 0, ba.size());
 			}
 			return true;
 

--- a/src/main/java/ini/trakem2/io/RagMipMaps.java
+++ b/src/main/java/ini/trakem2/io/RagMipMaps.java
@@ -98,12 +98,12 @@ public final class RagMipMaps
 					ra.write(b[i]);
 				}
 				// Now write a compressed alpha channel:
-				final ByteArrayOutputStream ba = new ByteArrayOutputStream(b.length);
+				final ImageSaver.ExposedByteArrayOutputStream ba = new ImageSaver.ExposedByteArrayOutputStream(b.length);
 				final DeflaterOutputStream def = new DeflaterOutputStream(ba, new Deflater(4, false), 1024);
 				def.write(b[b.length-1]);
 				def.finish();
 				def.flush(); // likely not needed
-				ra.write((byte[])ImageSaver.Bbuf.get(ba), 0, ba.size());
+				ra.write(ba.rawBuf(), 0, ba.size());
 			}
 			return true;
 

--- a/src/main/java/ini/trakem2/tree/DNDTree.java
+++ b/src/main/java/ini/trakem2/tree/DNDTree.java
@@ -424,27 +424,12 @@ public abstract class DNDTree extends JTree implements TreeExpansionListener, Ke
 		setExpandedSilently(node, b);
 	}
 
-	static private final java.lang.reflect.Field f_expandedState = DNDTree.getExpandedStateField();
-
-	static private final java.lang.reflect.Field getExpandedStateField() {
-		try {
-			java.lang.reflect.Field f = JTree.class.getDeclaredField("expandedState");
-			f.setAccessible(true);
-			return f;
-		} catch (Exception e) {
-			Utils.log2("ERROR: " + e);
-			return null;
-		}
-	}
-
-	@SuppressWarnings("unchecked")
 	public void setExpandedSilently(final DefaultMutableTreeNode node, final boolean b) {
-		try {
-			final Hashtable<Object,Boolean> ht = (Hashtable<Object,Boolean>)f_expandedState.get(this);
-			ht.put(new TreePath(node.getPath()), b); // this queries directly the expandedState transient private Hashtable of the JTree
-		 } catch (Exception e) {
-			 Utils.log2("ERROR: " + e); // no IJError, potentially lots of text printed in failed applets
-		 }
+		if (b) {
+			expandPath(new TreePath(node.getPath()));
+		} else {
+			collapsePath(new TreePath(node.getPath()));
+		}
 	}
 
 	/** Get the map of Thing vs. expanded state for all nodes that have children. */
@@ -452,23 +437,10 @@ public abstract class DNDTree extends JTree implements TreeExpansionListener, Ke
 		return getExpandedStates(new HashMap<Thing,Boolean>());
 	}
 
-	/** Get the map of Thing vs. expanded state for all nodes that have children,
-	 * and put the mappins into the {@code m}.
-	 * @return {@code m}
-	 */
+	/** Placeholder code now we don't worry about expanded states */
 	@SuppressWarnings("unchecked")
 	public HashMap<Thing,Boolean> getExpandedStates(final HashMap<Thing,Boolean> m) {
-		try {
-			final Hashtable<TreePath,Boolean> ht = (Hashtable<TreePath,Boolean>)f_expandedState.get(this);
-			for (final Map.Entry<TreePath,Boolean> e : ht.entrySet()) {
-				final Thing t = (Thing)((DefaultMutableTreeNode)e.getKey().getLastPathComponent()).getUserObject();
-				if (t.hasChildren()) m.put(t, e.getValue());
-			}
-			return m;
-		} catch (Exception e) {
-			IJError.print(e);
-		}
-		return null;
+		return m;
 	}
 
 	/** Check if there is a node holding the given Thing, and whether such node is expanded. */
@@ -478,30 +450,8 @@ public abstract class DNDTree extends JTree implements TreeExpansionListener, Ke
 		return isExpanded(node);
 	}
 
-	@SuppressWarnings("unchecked")
 	public boolean isExpanded(final DefaultMutableTreeNode node) {
-		try {
-			final Hashtable<Object,Boolean> ht = (Hashtable<Object,Boolean>)f_expandedState.get(this);
-			return Boolean.TRUE.equals(ht.get(new TreePath(node.getPath()))); // this queries directly the expandedState transient private HashMap of the JTree
-		 } catch (Exception e) {
-			 Utils.log2("ERROR: " + e); // no IJError, potentially lots of text printed in failed applets
-			 return false;
-		 }
-
-		/* // Java's idiotic API confuses isExpanded with isVisible, making them equal! The JTree.isVisible() check should not be done within the JTree.isExpanded() method!
-		DefaultMutableTreeNode node = findNode(thing, this);
-		Utils.log2("node is " + node);
-		if (null == node) return false;
-		TreePath path = new TreePath(node.getPath());
-		//return this.isExpanded(new TreePath(node.getPath())); // the API is ludicrous: isExpanded, isCollapsed and isVisible return a value relative to whether the node is visible, not its specific expanded state.
-		Utils.log("contains: " + hs_expanded_paths.contains(path));
-		//return hs_expanded_paths.contains(node.getPath());
-		for (Iterator it = hs_expanded_paths.iterator(); it.hasNext(); ) {
-			if (path.equals(it.next())) return true;
-		}
-		Utils.log2("thing not expanded: " + thing);
-		return false;
-		*/
+		return super.isExpanded(new TreePath(node.getPath()));
 	}
 
 	//private HashSet hs_expanded_paths = new HashSet();


### PR DESCRIPTION
When saving the code no longer tries to directly access the byte buffer, it instead accesses it via class methods. Also removed the reflection into JTree that was used to preserve tree status. Have tested both changes on Fiji.