### PR TITLE
Update TrakEM2 for java 21

### DIFF
--- a/src/main/java/ini/trakem2/Project.java
+++ b/src/main/java/ini/trakem2/Project.java
@@ -582,6 +582,8 @@ public class Project extends DBObject {
 
 		// set ProjectThing nodes expanded state, now that the trees exist
 		try {
+			// Restoring the expanded state of JTree nodes requires reflection, so skip.
+			/*
 			java.lang.reflect.Field f = JTree.class.getDeclaredField("expandedState");
 			f.setAccessible(true);
 			Hashtable<Object,Object> ht_exp = (Hashtable<Object,Object>) f.get(project.project_tree);
@@ -601,6 +603,7 @@ public class Project extends DBObject {
 					ht_exp.put(new TreePath(nd.getPath()), expanded);
 				}
 			}
+			*/
 			project.project_tree.updateUILater(); // very important!!
 		} catch (Exception e) {
 			IJError.print(e);

--- a/src/main/java/ini/trakem2/Project.java
+++ b/src/main/java/ini/trakem2/Project.java
@@ -132,7 +132,7 @@ public class Project extends DBObject {
 		new Thread() { public void run() { try {
 			setPriority(Thread.NORM_PRIORITY);
 			setContextClassLoader(ij.IJ.getClassLoader());
-			final String plugins_dir = Utils.fixDir(ij.Menus.getPlugInsPath());
+			final String plugins_dir = Utils.fixDir(null == ij.Menus.getPlugInsPath() ? System.getProperty("user.dir") : ij.Menus.getPlugInsPath());
 			synchronized (PLUGIN_SOURCES) {
 			for (String name : new File(plugins_dir).list()) {
 				File f = new File(name);

--- a/src/main/java/ini/trakem2/display/LayerSet.java
+++ b/src/main/java/ini/trakem2/display/LayerSet.java
@@ -1147,75 +1147,6 @@ public final class LayerSet extends Displayable implements Bucketable { // Displ
 		}
 	}
 
-	private static java.lang.reflect.Field sbvalue = null;
-	private static java.lang.reflect.Field sbcoder = null;
-	private static final ThreadLocal<char[]> sbCharBuffer = ThreadLocal.withInitial(() -> new char[1024]);
-	static {
-		try {
-			final Class<?> asb = StringBuilder.class.getSuperclass();
-			sbvalue = asb.getDeclaredField("value");
-			sbvalue.setAccessible(true);
-			try {
-				sbcoder = asb.getDeclaredField("coder");
-				sbcoder.setAccessible(true);
-			} catch (NoSuchFieldException ignored) {
-				// Older JVMs expose char[] directly; coder field absent.
-			}
-		} catch (Exception e) {
-			IJError.print(e);
-		}
-	}
-
-	private static char[] ensureCharBuffer(final int length) {
-		char[] buffer = sbCharBuffer.get();
-		if (buffer.length < length) {
-			buffer = new char[length];
-			sbCharBuffer.set(buffer);
-		}
-		return buffer;
-	}
-
-	private static void writeStringBuilder(final java.io.Writer writer, final StringBuilder builder) throws java.io.IOException {
-		if (null == sbvalue) {
-			writer.write(builder.toString());
-			return;
-		}
-		try {
-			final Object value = sbvalue.get(builder);
-			final int length = builder.length();
-			if (value instanceof char[]) {
-				writer.write((char[]) value, 0, length);
-				return;
-			}
-			if (value instanceof byte[]) {
-				if (null == sbcoder) {
-					writer.write(builder.toString());
-					return;
-				}
-				final byte[] bytes = (byte[]) value;
-				final char[] chars = ensureCharBuffer(length);
-				final byte coder = sbcoder.getByte(builder);
-				if (0 == coder) { // LATIN1
-					for (int i = 0; i < length; i++) {
-						chars[i] = (char) (bytes[i] & 0xFF);
-					}
-				} else { // UTF16
-					int bi = 0;
-					for (int i = 0; i < length; i++) {
-						final int lo = bytes[bi++] & 0xFF;
-						final int hi = bytes[bi++] & 0xFF;
-						chars[i] = (char) (lo | (hi << 8));
-					}
-				}
-				writer.write(chars, 0, length);
-				return;
-			}
-		} catch (IllegalAccessException e) {
-			IJError.print(e);
-		}
-		writer.write(builder.toString());
-	}
-
 	public void exportXML(final java.io.Writer writer, final String indent, final XMLOptions options) throws Exception {
 		final StringBuilder sb_body = new StringBuilder(512);
 		sb_body.append(indent).append("<t2_layer_set\n");
@@ -1255,7 +1186,7 @@ public final class LayerSet extends Displayable implements Bucketable { // Displ
 			       .append(in).append("/>\n")
 			;
 		}
-		writeStringBuilder(writer, sb_body);
+		writer.write(sb_body.toString());
 		// Count objects
 		int done = 0;
 		int total = 0;
@@ -1268,7 +1199,7 @@ public final class LayerSet extends Displayable implements Bucketable { // Displ
 			for (final ZDisplayable zd : al_zdispl) {
 				sb_body.setLength(0);
 				zd.exportXML(sb_body, in, options);
-				writeStringBuilder(writer, sb_body); // each separately, for they can be huge
+				writer.write(sb_body.toString()); // each separately, for they can be huge
 			}
 			done += al_zdispl.size();
 			Utils.showProgress(done / (double)total);
@@ -1279,7 +1210,7 @@ public final class LayerSet extends Displayable implements Bucketable { // Displ
 			for (final Layer la : al_layers) {
 				sb_body.setLength(0);
 				la.exportXML(sb_body, in, options);
-				writeStringBuilder(writer, sb_body);
+				writer.write(sb_body.toString());
 				done += la.getDisplayableList().size();
 				Utils.showProgress(done / (double)total);
 			}
@@ -1287,7 +1218,7 @@ public final class LayerSet extends Displayable implements Bucketable { // Displ
 		sb_body.setLength(0);
 		if (sb_body.length() > 0) {
 			super.restXML(sb_body, in, options);
-			writeStringBuilder(writer, sb_body);
+			writer.write(sb_body.toString());
 		}
 		writer.write(indent + "</t2_layer_set>\n");
 	}

--- a/src/main/java/ini/trakem2/display/Patch.java
+++ b/src/main/java/ini/trakem2/display/Patch.java
@@ -45,7 +45,7 @@ import java.awt.image.DirectColorModel;
 import java.awt.image.MemoryImageSource;
 import java.awt.image.PixelGrabber;
 import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
+import ini.trakem2.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileReader;
@@ -1629,7 +1629,7 @@ public final class Patch extends Displayable implements ImageData {
 			zos.closeEntry();
 			zos.close();
 
-			ra.write((byte[])ImageSaver.Bbuf.get(ba), 0, ba.size());
+			ra.write(ba.getByteArray(), 0, ba.size());
 			return true;
 		} catch (final Throwable e) {
 			IJError.print(e);

--- a/src/main/java/ini/trakem2/io/ByteArrayOutputStream.java
+++ b/src/main/java/ini/trakem2/io/ByteArrayOutputStream.java
@@ -1,0 +1,19 @@
+package ini.trakem2.io;
+
+/**
+ * The purpose of this class is to provide public access to the protected byte[] buf in ByteArrayOutputStream.
+ */
+public class ByteArrayOutputStream extends java.io.ByteArrayOutputStream {
+
+	public ByteArrayOutputStream() {
+		super();
+	}
+	
+	public ByteArrayOutputStream(final int length) {
+		super(length);
+	}
+	
+	public byte[] getByteArray() {
+		return super.buf;
+	}
+}

--- a/src/main/java/ini/trakem2/io/ImageSaver.java
+++ b/src/main/java/ini/trakem2/io/ImageSaver.java
@@ -51,7 +51,6 @@ import java.awt.image.SampleModel;
 import java.awt.image.WritableRaster;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -61,7 +60,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
-import java.lang.reflect.Field;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -243,10 +241,11 @@ public class ImageSaver {
 				writer.write(null, iioImage, param);
 				// Now write to disk
 				FileChannel ch = null;
+				RandomAccessFile ra = null;
 				try {
 					// Now write to disk in the fastest way possible
-					final RandomAccessFile ra = new RandomAccessFile(new File(path), "rw");
-					final ByteBuffer bb = ByteBuffer.wrap((byte[])Bbuf.get(baos), 0, baos.size());
+					ra = new RandomAccessFile(new File(path), "rw");
+					final ByteBuffer bb = ByteBuffer.wrap(baos.getByteArray(), 0, baos.size());
 					ch = ra.getChannel();
 					while (bb.hasRemaining()) {
 						ch.write(bb);
@@ -254,6 +253,7 @@ public class ImageSaver {
 				} finally {
 					if (null != ch) ch.close();
 					ios.close();
+					if (null != ra) ra.close();
 				}
 				
 				
@@ -467,18 +467,6 @@ public class ImageSaver {
 		sb.append((char)0);
 		return new String(sb);
 	}
-
-	static public final Field Bbuf;
-	static {
-		Field b = null;
-		try {
-			b = ByteArrayOutputStream.class.getDeclaredField("buf");
-			b.setAccessible(true);
-		} catch (Exception e) {
-			IJError.print(e);
-		}
-		Bbuf = b;
-	}
 	
 	/** Based on EM images of neuropils with outside alpha masks.
 	 * Fitted a polynomial on the length of file vs area size. */
@@ -510,7 +498,7 @@ public class ImageSaver {
 						writer.write(writer.getDefaultStreamMetadata(iwp), new IIOImage(awt, null, null), iwp);
 						// Now write to disk in the fastest way possible
 						ra = new RandomAccessFile(new File(path), "rw");
-						final ByteBuffer bb = ByteBuffer.wrap((byte[])Bbuf.get(baos), 0, baos.size());
+						final ByteBuffer bb = ByteBuffer.wrap(baos.getByteArray(), 0, baos.size());
 						ch = ra.getChannel();
 						while (bb.hasRemaining()) {
 							ch.write(bb);
@@ -519,6 +507,7 @@ public class ImageSaver {
 					} finally {
 						if (null != ch) ch.close();
 						ios.close();
+						if (null != ra) ra.close();
 					}
 					return true; // only one: com.sun.imageio.plugins.jpeg.JPEGImageWriter
 				}
@@ -645,7 +634,6 @@ public class ImageSaver {
 		g.drawImage(some, 0, 0, null);
 		some.flush();
 		g.drawImage(awt, 0, 0, null);
-		@SuppressWarnings("serial")
 		java.awt.Canvas canvas = new java.awt.Canvas() {
 			public void paint(Graphics g) {
 				g.drawImage(background, 0, 0, null);

--- a/src/main/java/ini/trakem2/io/RagMipMaps.java
+++ b/src/main/java/ini/trakem2/io/RagMipMaps.java
@@ -29,7 +29,6 @@ import ini.trakem2.utils.Utils;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -103,7 +102,7 @@ public final class RagMipMaps
 				def.write(b[b.length-1]);
 				def.finish();
 				def.flush(); // likely not needed
-				ra.write((byte[])ImageSaver.Bbuf.get(ba), 0, ba.size());
+				ra.write(ba.getByteArray(), 0, ba.size());
 			}
 			return true;
 

--- a/src/main/java/ini/trakem2/tree/DNDTree.java
+++ b/src/main/java/ini/trakem2/tree/DNDTree.java
@@ -424,8 +424,9 @@ public abstract class DNDTree extends JTree implements TreeExpansionListener, Ke
 		setExpandedSilently(node, b);
 	}
 
-	static private final java.lang.reflect.Field f_expandedState = DNDTree.getExpandedStateField();
+	//static private final java.lang.reflect.Field f_expandedState = DNDTree.getExpandedStateField();
 
+	/*
 	static private final java.lang.reflect.Field getExpandedStateField() {
 		try {
 			java.lang.reflect.Field f = JTree.class.getDeclaredField("expandedState");
@@ -436,13 +437,15 @@ public abstract class DNDTree extends JTree implements TreeExpansionListener, Ke
 			return null;
 		}
 	}
+	*/
 
 	@SuppressWarnings("unchecked")
 	public void setExpandedSilently(final DefaultMutableTreeNode node, final boolean b) {
 		try {
-			final Hashtable<Object,Boolean> ht = (Hashtable<Object,Boolean>)f_expandedState.get(this);
-			ht.put(new TreePath(node.getPath()), b); // this queries directly the expandedState transient private Hashtable of the JTree
-		 } catch (Exception e) {
+			// Can't access via reflection, so do nothing
+			//final Hashtable<Object,Boolean> ht = (Hashtable<Object,Boolean>)f_expandedState.get(this);
+			//ht.put(new TreePath(node.getPath()), b); // this queries directly the expandedState transient private Hashtable of the JTree
+		} catch (Exception e) {
 			 Utils.log2("ERROR: " + e); // no IJError, potentially lots of text printed in failed applets
 		 }
 	}
@@ -453,17 +456,20 @@ public abstract class DNDTree extends JTree implements TreeExpansionListener, Ke
 	}
 
 	/** Get the map of Thing vs. expanded state for all nodes that have children,
-	 * and put the mappins into the {@code m}.
+	 * and put the mappings into the {@code m}.
 	 * @return {@code m}
 	 */
 	@SuppressWarnings("unchecked")
 	public HashMap<Thing,Boolean> getExpandedStates(final HashMap<Thing,Boolean> m) {
 		try {
+			// Can't access expanded states except via reflection, so do nothing.
+			/*
 			final Hashtable<TreePath,Boolean> ht = (Hashtable<TreePath,Boolean>)f_expandedState.get(this);
 			for (final Map.Entry<TreePath,Boolean> e : ht.entrySet()) {
 				final Thing t = (Thing)((DefaultMutableTreeNode)e.getKey().getLastPathComponent()).getUserObject();
 				if (t.hasChildren()) m.put(t, e.getValue());
 			}
+			*/
 			return m;
 		} catch (Exception e) {
 			IJError.print(e);
@@ -478,12 +484,13 @@ public abstract class DNDTree extends JTree implements TreeExpansionListener, Ke
 		return isExpanded(node);
 	}
 
-	@SuppressWarnings("unchecked")
 	public boolean isExpanded(final DefaultMutableTreeNode node) {
 		try {
-			final Hashtable<Object,Boolean> ht = (Hashtable<Object,Boolean>)f_expandedState.get(this);
-			return Boolean.TRUE.equals(ht.get(new TreePath(node.getPath()))); // this queries directly the expandedState transient private HashMap of the JTree
-		 } catch (Exception e) {
+			//final Hashtable<Object,Boolean> ht = (Hashtable<Object,Boolean>)f_expandedState.get(this);
+			//return Boolean.TRUE.equals(ht.get(new TreePath(node.getPath()))); // this queries directly the expandedState transient private HashMap of the JTree
+			// Does not quite work like the above but it will do something and return a boolean
+			return this.isExpanded(new TreePath(node.getPath()));
+		} catch (Exception e) {
 			 Utils.log2("ERROR: " + e); // no IJError, potentially lots of text printed in failed applets
 			 return false;
 		 }
@@ -506,7 +513,7 @@ public abstract class DNDTree extends JTree implements TreeExpansionListener, Ke
 
 	//private HashSet hs_expanded_paths = new HashSet();
 
-	/** Sense node expansion events (the method name is missleading). */
+	/** Sense node expansion events (the method name is misleading). */
 	public void treeCollapsed(TreeExpansionEvent tee) {
 		TreePath path = tee.getPath();
 		//hs_expanded_paths.remove(path);

--- a/src/test/java/ini/trakem2/display/LaunchTrakEM2inImageJ.java
+++ b/src/test/java/ini/trakem2/display/LaunchTrakEM2inImageJ.java
@@ -1,0 +1,20 @@
+package ini.trakem2.display;
+
+import java.io.File;
+
+import ij.ImageJ;
+import ini.trakem2.Project;
+
+public class LaunchTrakEM2inImageJ {
+	
+	static public void main(String[] args) {
+		final ImageJ ij = new ImageJ();
+		
+		final String folder = "/home/albert/Desktop/t2/trakem2-java-21/";
+		if (new File(folder + "test.xml").exists()) {
+			final Project project = Project.openFSProject(folder + "test.xml", true);
+		} else {
+			final Project project = Project.newFSProject("blank", null, "/home/albert/Desktop/t2/trakem2-java-21/", true);
+		}
+	}
+}


### PR DESCRIPTION
* Removes reflection access to core java libraries.
* Ensures image saving for mipmaps is still done without duplicating byte arrays, which would incur into a significant performance penalty.
* Mitigates as much as possible the now missing feature to store and restore the expanded state of JTree nodes in the TrakEM2 window.